### PR TITLE
Add Labels layer to display segmentation result in napari using APR.

### DIFF
--- a/pyapr/viewer/__init__.py
+++ b/pyapr/viewer/__init__.py
@@ -5,4 +5,4 @@ from .compressInteractive import *
 from .raycastViewer import *
 from .particleScatterPlot import particle_scatter_plot
 
-from ._apr_napari_layer import get_napari_layer
+from ._apr_napari_layer import apr_to_napari_Image, apr_to_napari_Labels


### PR DESCRIPTION
Add layer to display segmentation label in napari and correct the rolling dimension bug with squeezing the reconstructed patch.