### PR TITLE
tag-based versioning and deployment

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -94,8 +94,7 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install wheel
-          pip install setuptools
+          pip install wheel setuptools setuptools_scm
           python3 setup.py bdist_wheel -b ${{ env.CMAKE_BUILD_DIR }}
 
       - name: Python Install

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -103,5 +103,4 @@ jobs:
 
       - name: Python Test
         run: |
-          which python
           python3 -m unittest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -93,12 +93,15 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
+          pip install wheel
           pip install setuptools
+          python3 setup.py bdist_wheel -b ${{ env.CMAKE_BUILD_DIR }}
 
       - name: Python Install
         run: |
-          python setup.py install
+          pip install dist/pyapr*.whl
 
       - name: Python Test
         run: |
+          which python
           python3 -m unittest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Python Install
         run: |
-          pip install --find-links=dist pyapr
+          pip install dist/pyapr*.whl
 
       - name: Python Test
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -93,13 +93,11 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install wheel
           pip install setuptools
-          python3 setup.py bdist_wheel -b ${{ env.CMAKE_BUILD_DIR }}
 
       - name: Python Install
         run: |
-          pip install dist/pyapr*.whl
+          python setup.py install
 
       - name: Python Test
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
 
       - name: Submodule recursive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,15 +135,18 @@ jobs:
           name: ${{ matrix.os }}-wheels
           path: ${{matrix.builddir}}/
 
-  fake-deploy:
+  deploy:
     runs-on: ubuntu-latest
     needs: test
     name: download and print artifacts
     steps:
-      - name: downlaod ubuntu artifacts
+      - name: download wheels from artifacts
         uses: actions/download-artifact@v2
         with:
-          name: ubuntu-latest-wheels
+          name:
+            - ubuntu-latest-wheels
+            - macos-latest-wheels
+            - windows-latest-wheels
           path: wheelhouse
 
       - name: print stuff

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,9 +152,9 @@ jobs:
     if: contains(github.ref, 'tags')  # only run on tagged commits starting with "v*"
     steps:
       - name: Download wheels from artifacts
-          uses: actions/download-artifact@v2
-          with:
-            path: wheelhouse
+        uses: actions/download-artifact@v2
+        with:
+          path: wheelhouse
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
     needs:
       - check-wheels
     name: publish to pypi
-    if: contains(github.ref, 'tags')  # only run on tagged commits starting with "v*"
+#    if: contains(github.ref, 'tags')  # only run on tagged commits starting with "v*"
     steps:
       - name: Download wheels from artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,116 +19,116 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-#  build-wheels:
-#    name: ${{ matrix.os }} build and test wheels
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os: [ubuntu-latest, macos-latest, windows-latest]
-#        include:
-#          - os: windows-latest
-#            triplet: x64-windows
-#            openmp: ON
-#            builddir: dist/wheelhouse
-#            builddir1: dist
-#          - os: ubuntu-latest
-#            triplet: x64-linux
-#            builddir: wheelhouse
-#            builddir1: wheelhouse
-#          - os: macos-latest
-#            triplet: x64-osx
-#            builddir: wheelhouse
-#            builddir1: wheelhouse
-#    env:
-#      # Indicates the CMake build directory where project files and binaries are being produced.
-#      CMAKE_BUILD_DIR: ${{ github.workspace }}/builddir/
-#      # Indicates the location of the vcpkg as a Git submodule of the project repository.
-#      VCPKG_ROOT: ${{ github.workspace }}/external/LibAPR/vcpkg
-#      CIBW_ENVIRONMENT_WINDOWS: EXTRA_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -DVCPKG_MANIFEST_DIR=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\"
-#      CIBW_BUILD: "cp37-* cp38-* cp39-*"
-#      CIBW_ARCHS: "auto64"
-#      CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
-#      CIBW_BUILD_VERBOSITY: 1
-#      CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
-#      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python fix_windows_wheel.py {wheel} {dest_dir}"
-#      CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
-#      CIBW_TEST_SKIP: "*-win_amd64"  # skip tests on windows
-#      CIBW_BEFORE_BUILD_LINUX: "apt update && apt install -y libtiff5-dev libhdf5-dev"
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          fetch-depth: 0
-#          submodules: true
-#
-#      - name: Submodule recursive
-#        run: git submodule update --init --recursive
-#
-#      # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
-#      - uses: lukka/get-cmake@latest
-#      # Restore both vcpkg and its artifacts from the GitHub cache service.
-#      - name: Restore vcpkg and its artifacts.
-#        uses: actions/cache@v2
-#        with:
-#          # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
-#          # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
-#          # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
-#          path: |
-#            ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed/
-#            ${{ env.VCPKG_ROOT }}
-#            !${{ env.VCPKG_ROOT }}/buildtrees
-#            !${{ env.VCPKG_ROOT }}/packages
-#            !${{ env.VCPKG_ROOT }}/downloads
-#          # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg's Git commit id changes, or the list of packages changes. In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
-#          # The key includes: hash of the vcpkg.json file, the hash of the vcpkg Git commit id, and the used vcpkg's triplet. The vcpkg's commit id would suffice, but computing an hash out it does not harm.
-#          # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
-#          key: |
-#            ${{ hashFiles( 'external/LibAPR/vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
-#
-#      - name: Check file paths
-#        run: |
-#          cd ${{ github.workspace }}/external/LibAPR/vcpkg/scripts/buildsystems/
-#          ls
-#
-#      - name: Show content of workspace after cache has been restored
-#        run: find $RUNNER_WORKSPACE
-#        shell: bash
-#
-#      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly. As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
-#      - uses: ilammy/msvc-dev-cmd@v1
-#
-#      - uses: actions/setup-python@v2
-#        name: Install Python
-#        with:
-#          python-version: '3.7'
-#
-#      - name: Install cibuildwheel
-#        run: |
-#          python3 -m pip install cibuildwheel==1.10.0
-#
-#      - name: Install OpenMP dependencies with brew for OSX
-#        if: contains(matrix.os,'macos')
-#        run: |
-#          brew install libomp
-#          brew install c-blosc
-#          brew install hdf5
-#
-#      - name: Run cibuildwheel
-#        run: |
-#          python3 -m cibuildwheel --output-dir ${{matrix.builddir1}}
-#
-#      - name: Upload wheels as artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: ${{ matrix.os }}-wheels
-#          path: ${{matrix.builddir1}}/
-#          retention-days: 5
+  build-wheels:
+    name: ${{ matrix.os }} build and test wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+            triplet: x64-windows
+            openmp: ON
+            builddir: dist/wheelhouse
+            builddir1: dist
+          - os: ubuntu-latest
+            triplet: x64-linux
+            builddir: wheelhouse
+            builddir1: wheelhouse
+          - os: macos-latest
+            triplet: x64-osx
+            builddir: wheelhouse
+            builddir1: wheelhouse
+    env:
+      # Indicates the CMake build directory where project files and binaries are being produced.
+      CMAKE_BUILD_DIR: ${{ github.workspace }}/builddir/
+      # Indicates the location of the vcpkg as a Git submodule of the project repository.
+      VCPKG_ROOT: ${{ github.workspace }}/external/LibAPR/vcpkg
+      CIBW_ENVIRONMENT_WINDOWS: EXTRA_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -DVCPKG_MANIFEST_DIR=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\"
+      CIBW_BUILD: "cp37-* cp38-* cp39-*"
+      CIBW_ARCHS: "auto64"
+      CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python fix_windows_wheel.py {wheel} {dest_dir}"
+      CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
+      CIBW_TEST_SKIP: "*-win_amd64"  # skip tests on windows
+      CIBW_BEFORE_BUILD_LINUX: "apt update && apt install -y libtiff5-dev libhdf5-dev"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Submodule recursive
+        run: git submodule update --init --recursive
+
+      # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
+      - uses: lukka/get-cmake@latest
+      # Restore both vcpkg and its artifacts from the GitHub cache service.
+      - name: Restore vcpkg and its artifacts.
+        uses: actions/cache@v2
+        with:
+          # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
+          # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
+          # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
+          path: |
+            ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed/
+            ${{ env.VCPKG_ROOT }}
+            !${{ env.VCPKG_ROOT }}/buildtrees
+            !${{ env.VCPKG_ROOT }}/packages
+            !${{ env.VCPKG_ROOT }}/downloads
+          # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg's Git commit id changes, or the list of packages changes. In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
+          # The key includes: hash of the vcpkg.json file, the hash of the vcpkg Git commit id, and the used vcpkg's triplet. The vcpkg's commit id would suffice, but computing an hash out it does not harm.
+          # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
+          key: |
+            ${{ hashFiles( 'external/LibAPR/vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
+
+      - name: Check file paths
+        run: |
+          cd ${{ github.workspace }}/external/LibAPR/vcpkg/scripts/buildsystems/
+          ls
+
+      - name: Show content of workspace after cache has been restored
+        run: find $RUNNER_WORKSPACE
+        shell: bash
+
+      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly. As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python3 -m pip install cibuildwheel==1.10.0
+
+      - name: Install OpenMP dependencies with brew for OSX
+        if: contains(matrix.os,'macos')
+        run: |
+          brew install libomp
+          brew install c-blosc
+          brew install hdf5
+
+      - name: Run cibuildwheel
+        run: |
+          python3 -m cibuildwheel --output-dir ${{matrix.builddir1}}
+
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-wheels
+          path: ${{matrix.builddir1}}/
+          retention-days: 5
 
   windows-tests:
     name: windows py${{ matrix.python-version }} tests
     runs-on: windows-latest
-#    needs: build-wheels
+    needs: build-wheels
     strategy:
       fail-fast: false
       matrix:
@@ -139,39 +139,34 @@ jobs:
             openmp: ON
 
     steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#        with:
-#          submodules: false
-#
-#      - name: Set up Python
-#        uses: actions/setup-python@v2
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#
-#      - name: Download wheels from artifacts
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: windows-latest-wheels
-#          path: wheelhouse
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download wheels from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: windows-latest-wheels
+          path: wheelhouse
 
       - name: Set version string
         shell: bash
         run: echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
 
-      - name: print version string
+      - name: Install package from wheel
         run: |
-          echo "${{ env.py_version_str }}"
-          pip install pyapr-*${{ env.py_version_str }}*.whl
+          python -m pip install --upgrade pip
+          pip install wheelhouse/windows-latest-wheels/pyapr-*${{ env.py_version_str }}*.whl
 
-#      - name: Install package from wheel
-#        run: |
-#          python -m pip install --upgrade pip
-#          pip install wheelhouse/windows-latest-wheels/pyapr-*${{ env.py_version_str }}*.whl
-#
-#      - name: Run tests
-#        run: |
-#          python -m unittest discover -s ${{ github.workspace }}
+      - name: Run tests
+        run: |
+          python -m unittest discover -s ${{ github.workspace }}
 
 
   deploy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,13 +157,12 @@ jobs:
 
       - name: Set version string
         shell: bash
-        run: |
-          echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
-          echo "${{ env.py_version_str }}"
+        run: echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
 
       - name: print version string
-        shell: bash
-        run: echo "${{ env.py_version_str }}"
+        run: |
+          echo "${{ env.py_version_str }}"
+          pip install pyapr-*${{ env.py_version_str }}*.whl
 
 #      - name: Install package from wheel
 #        run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,10 +143,6 @@ jobs:
       - name: download wheels from artifacts
         uses: actions/download-artifact@v2
         with:
-          name:
-            - ubuntu-latest-wheels
-            - macos-latest-wheels
-            - windows-latest-wheels
           path: wheelhouse
 
       - name: print stuff

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.
       VCPKG_ROOT: ${{ github.workspace }}/external/LibAPR/vcpkg
       CIBW_ENVIRONMENT_WINDOWS: EXTRA_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -DVCPKG_MANIFEST_DIR=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\"
-      CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+      CIBW_BUILD: "cp37-* cp38-* cp39-*"
       CIBW_ARCHS: "auto64"
       CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
       CIBW_BUILD_VERBOSITY: 3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,9 @@ jobs:
       CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
       CIBW_ARCHS: "auto64"
       CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
-      TWINE_USERNAME: __token__
       CIBW_BUILD_VERBOSITY: 3
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
+      CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
 #      CIBW_BEFORE_TEST_LINUX: "pip install -r requirements.txt"
 #      CIBW_TEST_COMMAND_LINUX: "python3 -m unittest discover -s ${{ github.workspace }}"
       CIBW_BEFORE_BUILD_LINUX: "apt update && apt install -y libtiff5-dev libhdf5-dev"
@@ -125,28 +125,54 @@ jobs:
           python3 -m pip install delvewheel
           python3 fix_windows_wheel.py
 
-#      - name: Install twine
-#        run: |
-#          python3 -m pip install twine
-
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-wheels
           path: ${{matrix.builddir}}/
 
-  deploy:
+  check-wheels:
     runs-on: ubuntu-latest
     needs: test
-    name: download and print artifacts
+    name: check wheels
     steps:
-      - name: download wheels from artifacts
+      - name: Download wheels from artifacts
         uses: actions/download-artifact@v2
         with:
           path: wheelhouse
 
-      - name: print stuff
-        run: ls -R wheelhouse
+      - name: Print wheels
+        run: ls wheelhouse/*wheels/*.whl
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs:
+      - check-wheels
+    name: publish to pypi
+    if: contains(github.ref, 'tags')  # only run on tagged commits starting with "v*"
+    steps:
+      - name: Download wheels from artifacts
+          uses: actions/download-artifact@v2
+          with:
+            path: wheelhouse
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U twine
+
+      - name: Publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          ls wheelhouse/*wheels/*.whl
+#          twine upload wheelhouse/*wheels/*.whl
 
 
 #      - name: Publish to test Pypi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,10 +158,10 @@ jobs:
       - name: Set version string
         run: |
           echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
-          echo ${{ env.py_version_str }}
+          echo "${{ env.py_version_str }}"
 
       - name: print version string
-        run: echo ${{ env.py_version_str }}
+        run: echo "${{ env.py_version_str }}"
 
 #      - name: Install package from wheel
 #        run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,8 @@ jobs:
 
       - name: Publish to test Pypi
         run: |
-          python3 -m twine upload --skip-existing --repository pypi ${{matrix.builddir}}/*.whl -p ${{ secrets.PYPI_API_TOKEN }}
+          ls ${{matrix.builddir}}/*.whl
+#          python3 -m twine upload --skip-existing --repository pypi ${{matrix.builddir}}/*.whl -p ${{ secrets.PYPI_API_TOKEN }}
 
 #      - name: Test release from pypi 3.7
 #        run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,9 @@ jobs:
       CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
       CIBW_BUILD_VERBOSITY: 3
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
-      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python {project}/fix_windows_wheel.py {wheel} {dest_dir}"
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python fix_windows_wheel.py {wheel} {dest_dir}"
       CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
-      CIBW_TEST_SKIP: "cp*-win*"  # skip tests on windows, as wheels are not fixed until after the cibw run
+#      CIBW_TEST_SKIP: "cp*-win*"  # skip tests on windows, as wheels are not fixed until after the cibw run
       CIBW_BEFORE_BUILD_LINUX: "apt update && apt install -y libtiff5-dev libhdf5-dev"
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,22 +1,26 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build and Deploy
+name: tests
 
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [master, develop]
+    branches:
+      - master
+    tags:
+      - "v*"
   pull_request:
-    branches: [ master, develop ]
+    branches:
+      - master
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  job:
-    name: ${{ matrix.os }}-build-and-test
+  test:
+    name: ${{ matrix.os }} test and build wheels
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -55,6 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: true
 
       - name: Submodule recursive
@@ -120,13 +125,34 @@ jobs:
           python3 -m pip install delvewheel
           python3 fix_windows_wheel.py
 
-      - name: Install twine
-        run: |
-          python3 -m pip install twine
+#      - name: Install twine
+#        run: |
+#          python3 -m pip install twine
 
-      - name: Publish to test Pypi
-        run: |
-          ls ${{matrix.builddir}}/*.whl
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-wheels
+          path: ${{matrix.builddir}}/
+
+  fake-deploy:
+    runs-on: ubuntu-latest
+    needs: test
+    name: download and print artifacts
+    steps:
+      - name: downlaod ubuntu artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: ubuntu-latest-wheels
+          path: wheelhouse
+
+      - name: print stuff
+        run: ls -R wheelhouse
+
+
+#      - name: Publish to test Pypi
+#        run: |
+#          ls ${{matrix.builddir}}/*.whl
 #          python3 -m twine upload --skip-existing --repository pypi ${{matrix.builddir}}/*.whl -p ${{ secrets.PYPI_API_TOKEN }}
 
 #      - name: Test release from pypi 3.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,11 +156,13 @@ jobs:
 #          path: wheelhouse
 
       - name: Set version string
+        shell: bash
         run: |
           echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
           echo "${{ env.py_version_str }}"
 
       - name: print version string
+        shell: bash
         run: echo "${{ env.py_version_str }}"
 
 #      - name: Install package from wheel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,18 +150,19 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels from artifacts
-          uses: actions/download-artifact@v2
-          with:
-            name: windows-latest-wheels
-            path: wheelhouse
+        uses: actions/download-artifact@v2
+        with:
+          name: windows-latest-wheels
+          path: wheelhouse
 
       - name: Install package from wheel
-          run: |
-            python -m pip install --upgrade pip
-            echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
-            pip install wheelhouse/windows-latest-wheels/pyapr-*${{ env.py_version_str }}*.whl
+        run: |
+          python -m pip install --upgrade pip
+          echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
+          pip install wheelhouse/windows-latest-wheels/pyapr-*${{ env.py_version_str }}*.whl
 
       - name: Run tests
+        run: |
           python -m unittest discover -s ${{ github.workspace }}
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.
       VCPKG_ROOT: ${{ github.workspace }}/external/LibAPR/vcpkg
       CIBW_ENVIRONMENT_WINDOWS: EXTRA_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -DVCPKG_MANIFEST_DIR=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\"
-      CIBW_BUILD: "cp37-* cp38-* cp39-*"
+      CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
       CIBW_ARCHS: "auto64"
       CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
       CIBW_BUILD_VERBOSITY: 1
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         include:
           - os: windows-latest
             triplet: x64-windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,7 +160,9 @@ jobs:
         run: echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
 
       - name: Install package from wheel
+        shell: bash
         run: |
+          ls -R wheelhouse
           python -m pip install --upgrade pip
           pip install wheelhouse/pyapr-*${{ env.py_version_str }}*.whl
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.8. 3.9]
         include:
           - os: windows-latest
             triplet: x64-windows
@@ -162,7 +162,7 @@ jobs:
       - name: Install package from wheel
         run: |
           python -m pip install --upgrade pip
-          pip install wheelhouse/windows-latest-wheels/pyapr-*${{ env.py_version_str }}*.whl
+          pip install wheelhouse/pyapr-*${{ env.py_version_str }}*.whl
 
       - name: Run tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
   windows-tests:
     name: windows py${{ matrix.python-version }} tests
     runs-on: windows-latest
-    needs: build-wheels
+#    needs: build-wheels
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python fix_windows_wheel.py {wheel} {dest_dir}"
       CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
-#      CIBW_TEST_SKIP: "cp*-win*"  # skip tests on windows, as wheels are not fixed until after the cibw run
+      CIBW_TEST_SKIP: "*-win_amd64"  # skip tests on windows, as wheels are not fixed until after the cibw run
       CIBW_BEFORE_BUILD_LINUX: "apt update && apt install -y libtiff5-dev libhdf5-dev"
 
     steps:
@@ -169,10 +169,11 @@ jobs:
       - name: Publish
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+#          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
         run: |
           ls wheelhouse/*wheels/*.whl
-#          twine upload wheelhouse/*wheels/*.whl
+          twine upload --repository testpypi wheelhouse/*wheels/*.whl
 
 
 #      - name: Publish to test Pypi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
       CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
       CIBW_BUILD_VERBOSITY: 3
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python {project}/fix_windows_wheel.py {wheel} {dest_dir}"
       CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
 #      CIBW_BEFORE_TEST_LINUX: "pip install -r requirements.txt"
 #      CIBW_TEST_COMMAND_LINUX: "python3 -m unittest discover -s ${{ github.workspace }}"
@@ -118,12 +119,12 @@ jobs:
         run: |
           python3 -m cibuildwheel --output-dir ${{matrix.builddir1}}
 
-      - name: Fix windows wheels
-        if: contains(matrix.os,'windows')
-        run: |
-          python3 -m pip install wheel
-          python3 -m pip install delvewheel
-          python3 fix_windows_wheel.py
+#      - name: Fix windows wheels
+#        if: contains(matrix.os,'windows')
+#        run: |
+#          python3 -m pip install wheel
+#          python3 -m pip install delvewheel
+#          python3 fix_windows_wheel.py
 
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-wheels
-          path: ${{matrix.builddir}}/
+          path: ${{matrix.builddir1}}/
 
   check-wheels:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,111 +19,111 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build-wheels:
-    name: ${{ matrix.os }} build and test wheels
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - os: windows-latest
-            triplet: x64-windows
-            openmp: ON
-            builddir: dist/wheelhouse
-            builddir1: dist
-          - os: ubuntu-latest
-            triplet: x64-linux
-            builddir: wheelhouse
-            builddir1: wheelhouse
-          - os: macos-latest
-            triplet: x64-osx
-            builddir: wheelhouse
-            builddir1: wheelhouse
-    env:
-      # Indicates the CMake build directory where project files and binaries are being produced.
-      CMAKE_BUILD_DIR: ${{ github.workspace }}/builddir/
-      # Indicates the location of the vcpkg as a Git submodule of the project repository.
-      VCPKG_ROOT: ${{ github.workspace }}/external/LibAPR/vcpkg
-      CIBW_ENVIRONMENT_WINDOWS: EXTRA_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -DVCPKG_MANIFEST_DIR=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\"
-      CIBW_BUILD: "cp37-* cp38-* cp39-*"
-      CIBW_ARCHS: "auto64"
-      CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
-      CIBW_BUILD_VERBOSITY: 1
-      CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
-      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python fix_windows_wheel.py {wheel} {dest_dir}"
-      CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
-      CIBW_TEST_SKIP: "*-win_amd64"  # skip tests on windows
-      CIBW_BEFORE_BUILD_LINUX: "apt update && apt install -y libtiff5-dev libhdf5-dev"
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - name: Submodule recursive
-        run: git submodule update --init --recursive
-
-      # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
-      - uses: lukka/get-cmake@latest
-      # Restore both vcpkg and its artifacts from the GitHub cache service.
-      - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v2
-        with:
-          # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
-          # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
-          # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
-          path: |
-            ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed/
-            ${{ env.VCPKG_ROOT }}
-            !${{ env.VCPKG_ROOT }}/buildtrees
-            !${{ env.VCPKG_ROOT }}/packages
-            !${{ env.VCPKG_ROOT }}/downloads
-          # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg's Git commit id changes, or the list of packages changes. In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
-          # The key includes: hash of the vcpkg.json file, the hash of the vcpkg Git commit id, and the used vcpkg's triplet. The vcpkg's commit id would suffice, but computing an hash out it does not harm.
-          # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
-          key: |
-            ${{ hashFiles( 'external/LibAPR/vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
-
-      - name: Check file paths
-        run: |
-          cd ${{ github.workspace }}/external/LibAPR/vcpkg/scripts/buildsystems/
-          ls
-
-      - name: Show content of workspace after cache has been restored
-        run: find $RUNNER_WORKSPACE
-        shell: bash
-
-      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly. As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
-      - uses: ilammy/msvc-dev-cmd@v1
-
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.7'
-
-      - name: Install cibuildwheel
-        run: |
-          python3 -m pip install cibuildwheel==1.10.0
-
-      - name: Install OpenMP dependencies with brew for OSX
-        if: contains(matrix.os,'macos')
-        run: |
-          brew install libomp
-          brew install c-blosc
-          brew install hdf5
-
-      - name: Run cibuildwheel
-        run: |
-          python3 -m cibuildwheel --output-dir ${{matrix.builddir1}}
-
-      - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.os }}-wheels
-          path: ${{matrix.builddir1}}/
-          retention-days: 5
+#  build-wheels:
+#    name: ${{ matrix.os }} build and test wheels
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [ubuntu-latest, macos-latest, windows-latest]
+#        include:
+#          - os: windows-latest
+#            triplet: x64-windows
+#            openmp: ON
+#            builddir: dist/wheelhouse
+#            builddir1: dist
+#          - os: ubuntu-latest
+#            triplet: x64-linux
+#            builddir: wheelhouse
+#            builddir1: wheelhouse
+#          - os: macos-latest
+#            triplet: x64-osx
+#            builddir: wheelhouse
+#            builddir1: wheelhouse
+#    env:
+#      # Indicates the CMake build directory where project files and binaries are being produced.
+#      CMAKE_BUILD_DIR: ${{ github.workspace }}/builddir/
+#      # Indicates the location of the vcpkg as a Git submodule of the project repository.
+#      VCPKG_ROOT: ${{ github.workspace }}/external/LibAPR/vcpkg
+#      CIBW_ENVIRONMENT_WINDOWS: EXTRA_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -DVCPKG_MANIFEST_DIR=D:\\a\\PyLibAPR\\PyLibAPR\\external\\LibAPR\\"
+#      CIBW_BUILD: "cp37-* cp38-* cp39-*"
+#      CIBW_ARCHS: "auto64"
+#      CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
+#      CIBW_BUILD_VERBOSITY: 1
+#      CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
+#      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python fix_windows_wheel.py {wheel} {dest_dir}"
+#      CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
+#      CIBW_TEST_SKIP: "*-win_amd64"  # skip tests on windows
+#      CIBW_BEFORE_BUILD_LINUX: "apt update && apt install -y libtiff5-dev libhdf5-dev"
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#        with:
+#          fetch-depth: 0
+#          submodules: true
+#
+#      - name: Submodule recursive
+#        run: git submodule update --init --recursive
+#
+#      # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
+#      - uses: lukka/get-cmake@latest
+#      # Restore both vcpkg and its artifacts from the GitHub cache service.
+#      - name: Restore vcpkg and its artifacts.
+#        uses: actions/cache@v2
+#        with:
+#          # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
+#          # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
+#          # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
+#          path: |
+#            ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed/
+#            ${{ env.VCPKG_ROOT }}
+#            !${{ env.VCPKG_ROOT }}/buildtrees
+#            !${{ env.VCPKG_ROOT }}/packages
+#            !${{ env.VCPKG_ROOT }}/downloads
+#          # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg's Git commit id changes, or the list of packages changes. In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
+#          # The key includes: hash of the vcpkg.json file, the hash of the vcpkg Git commit id, and the used vcpkg's triplet. The vcpkg's commit id would suffice, but computing an hash out it does not harm.
+#          # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
+#          key: |
+#            ${{ hashFiles( 'external/LibAPR/vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
+#
+#      - name: Check file paths
+#        run: |
+#          cd ${{ github.workspace }}/external/LibAPR/vcpkg/scripts/buildsystems/
+#          ls
+#
+#      - name: Show content of workspace after cache has been restored
+#        run: find $RUNNER_WORKSPACE
+#        shell: bash
+#
+#      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly. As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
+#      - uses: ilammy/msvc-dev-cmd@v1
+#
+#      - uses: actions/setup-python@v2
+#        name: Install Python
+#        with:
+#          python-version: '3.7'
+#
+#      - name: Install cibuildwheel
+#        run: |
+#          python3 -m pip install cibuildwheel==1.10.0
+#
+#      - name: Install OpenMP dependencies with brew for OSX
+#        if: contains(matrix.os,'macos')
+#        run: |
+#          brew install libomp
+#          brew install c-blosc
+#          brew install hdf5
+#
+#      - name: Run cibuildwheel
+#        run: |
+#          python3 -m cibuildwheel --output-dir ${{matrix.builddir1}}
+#
+#      - name: Upload wheels as artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: ${{ matrix.os }}-wheels
+#          path: ${{matrix.builddir1}}/
+#          retention-days: 5
 
   windows-tests:
     name: windows py${{ matrix.python-version }} tests
@@ -132,38 +132,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7]
         include:
           - os: windows-latest
             triplet: x64-windows
             openmp: ON
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: false
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#        with:
+#          submodules: false
+#
+#      - name: Set up Python
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#
+#      - name: Download wheels from artifacts
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: windows-latest-wheels
+#          path: wheelhouse
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Download wheels from artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: windows-latest-wheels
-          path: wheelhouse
-
-      - name: Install package from wheel
+      - name: Set version string
         run: |
-          python -m pip install --upgrade pip
           echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
-          pip install wheelhouse/windows-latest-wheels/pyapr-*${{ env.py_version_str }}*.whl
+          echo ${{ env.py_version_str }}
 
-      - name: Run tests
-        run: |
-          python -m unittest discover -s ${{ github.workspace }}
+      - name: print version string
+        run: echo ${{ env.py_version_str }}
+
+#      - name: Install package from wheel
+#        run: |
+#          python -m pip install --upgrade pip
+#          pip install wheelhouse/windows-latest-wheels/pyapr-*${{ env.py_version_str }}*.whl
+#
+#      - name: Run tests
+#        run: |
+#          python -m unittest discover -s ${{ github.workspace }}
 
 
   deploy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       CIBW_BUILD: "cp37-* cp38-* cp39-*"
       CIBW_ARCHS: "auto64"
       CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_24"
-      CIBW_BUILD_VERBOSITY: 3
+      CIBW_BUILD_VERBOSITY: 1
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python fix_windows_wheel.py {wheel} {dest_dir}"
       CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,17 +29,13 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-            openmp: ON
-            builddir: dist/wheelhouse
-            builddir1: dist
+            builddir: dist
           - os: ubuntu-latest
             triplet: x64-linux
             builddir: wheelhouse
-            builddir1: wheelhouse
           - os: macos-latest
             triplet: x64-osx
             builddir: wheelhouse
-            builddir1: wheelhouse
     env:
       # Indicates the CMake build directory where project files and binaries are being produced.
       CMAKE_BUILD_DIR: ${{ github.workspace }}/builddir/
@@ -116,13 +112,13 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m cibuildwheel --output-dir ${{matrix.builddir1}}
+          python3 -m cibuildwheel --output-dir ${{matrix.builddir}}
 
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-wheels
-          path: ${{matrix.builddir1}}/
+          path: ${{matrix.builddir}}/
           retention-days: 5
 
   windows-tests:
@@ -136,7 +132,6 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-            openmp: ON
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8. 3.9]
+        python-version: [3.7, 3.8, 3.9]
         include:
           - os: windows-latest
             triplet: x64-windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: tests
+name: build
 
 # Controls when the workflow will run
 on:
@@ -19,8 +19,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  test:
-    name: ${{ matrix.os }} test and build wheels
+  build-wheels:
+    name: ${{ matrix.os }} build and test wheels
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "pip uninstall -y delocate && pip install git+https://github.com/Chia-Network/delocate.git && delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "pip install -U wheel delvewheel && python fix_windows_wheel.py {wheel} {dest_dir}"
       CIBW_TEST_COMMAND: "python3 -m unittest discover -s {project}"
-      CIBW_TEST_SKIP: "*-win_amd64"  # skip tests on windows, as wheels are not fixed until after the cibw run
+      CIBW_TEST_SKIP: "*-win_amd64"  # skip tests on windows
       CIBW_BEFORE_BUILD_LINUX: "apt update && apt install -y libtiff5-dev libhdf5-dev"
 
     steps:
@@ -86,7 +86,7 @@ jobs:
           key: |
             ${{ hashFiles( 'external/LibAPR/vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
 
-      - name: check file paths
+      - name: Check file paths
         run: |
           cd ${{ github.workspace }}/external/LibAPR/vcpkg/scripts/buildsystems/
           ls
@@ -118,38 +118,58 @@ jobs:
         run: |
           python3 -m cibuildwheel --output-dir ${{matrix.builddir1}}
 
-#      - name: Fix windows wheels
-#        if: contains(matrix.os,'windows')
-#        run: |
-#          python3 -m pip install wheel
-#          python3 -m pip install delvewheel
-#          python3 fix_windows_wheel.py
-
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-wheels
           path: ${{matrix.builddir1}}/
+          retention-days: 5
 
-  check-wheels:
-    runs-on: ubuntu-latest
-    needs: test
-    name: check wheels
+  windows-tests:
+    name: windows py${{ matrix.python-version }} tests
+    runs-on: windows-latest
+    needs: build-wheels
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: windows-latest
+            triplet: x64-windows
+            openmp: ON
+
     steps:
-      - name: Download wheels from artifacts
-        uses: actions/download-artifact@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          path: wheelhouse
+          submodules: false
 
-      - name: Print wheels
-        run: ls wheelhouse/*wheels/*.whl
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download wheels from artifacts
+          uses: actions/download-artifact@v2
+          with:
+            name: windows-latest-wheels
+            path: wheelhouse
+
+      - name: Install package from wheel
+          run: |
+            python -m pip install --upgrade pip
+            echo "py_version_str=cp$(echo ${{ matrix.python-version }} | tr -d -c 0-9)" >> $GITHUB_ENV
+            pip install wheelhouse/windows-latest-wheels/pyapr-*${{ env.py_version_str }}*.whl
+
+      - name: Run tests
+          python -m unittest discover -s ${{ github.workspace }}
+
 
   deploy:
     runs-on: ubuntu-latest
-    needs:
-      - check-wheels
+    needs: windows-tests
     name: publish to pypi
-#    if: contains(github.ref, 'tags')  # only run on tagged commits starting with "v*"
+    if: contains(github.ref, 'tags')  # only run on tagged commits starting with "v*"
     steps:
       - name: Download wheels from artifacts
         uses: actions/download-artifact@v2
@@ -169,19 +189,6 @@ jobs:
       - name: Publish
         env:
           TWINE_USERNAME: __token__
-#          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          ls wheelhouse/*wheels/*.whl
-          twine upload --repository testpypi wheelhouse/*wheels/*.whl
-
-
-#      - name: Publish to test Pypi
-#        run: |
-#          ls ${{matrix.builddir}}/*.whl
-#          python3 -m twine upload --skip-existing --repository pypi ${{matrix.builddir}}/*.whl -p ${{ secrets.PYPI_API_TOKEN }}
-
-#      - name: Test release from pypi 3.7
-#        run: |
-#          pip install pyapr
-#          python3 -m unittest
+          twine upload wheelhouse/*wheels/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ venv.bak/
 
 data/
 /processing
+
+# written by setuptools_scm
+**/_version.py
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,76 @@
+### Dependencies
+
+[LibAPR](https://github.com/AdaptiveParticles/LibAPR) is included as a submodule, and built alongside the wrappers.
+This requires the following packages:
+
+* HDF5 1.8.20 or higher
+* OpenMP > 3.0 (optional, but recommended)
+* CMake 3.6 or higher
+* LibTIFF 4.0 or higher
+
+The Python library additionally requires Python 3, and the packages listed in [requirements.txt](requirements.txt).
+
+### Installing dependencies on Linux
+
+On Ubuntu, install the `cmake`, `build-essential`, `libhdf5-dev` and `libtiff5-dev` packages (on other distributions,
+refer to the documentation there, the package names will be similar). OpenMP support is provided by the GCC compiler
+installed as part of the `build-essential` package.
+
+### Installing dependencies on OSX
+
+On OSX, install the `cmake`, `hdf5` and `libtiff`  [homebrew](https://brew.sh) packages and have the
+[Xcode command line tools](http://osxdaily.com/2014/02/12/install-command-line-tools-mac-os-x/) installed.
+If you want to compile with OpenMP support, also install the `llvm` package (this can also be done using homebrew),
+as the clang version shipped by Apple currently does not support OpenMP.
+
+### Note for windows users
+
+Please see https://github.com/AdaptiveParticles/LibAPR for the latest windows install instructions.
+
+## Building
+
+The repository requires submodules, so the repository needs to be cloned recursively:
+
+```
+git clone --recursive https://github.com/AdaptiveParticles/PyLibAPR.git
+```
+
+It is recommended to use a virtual environment, such as `virtualenv`. To set this up, use e.g.
+
+```
+pip3 install virtualenv
+python3 -m virtualenv myenv
+source myenv/bin/activate
+```
+
+The required Python packages can be installed via the command
+```
+pip install -r requirements.txt 
+```
+
+Once the dependencies are installed, PyLibAPR can be built via the setup.py script:
+```
+python setup.py install
+```
+
+### CMake build options
+
+There are two CMake options that can be given to enable or disable OpenMP and CUDA:
+
+| Option | Description | Default value |
+|:--|:--|:--|
+| PYAPR_USE_OPENMP | Enable multithreading via OpenMP | ON |
+| PYAPR_USE_CUDA | Build available CUDA functionality | OFF |
+
+When building via the setup.py script, these options can be set via the environment variable `CMAKE_COMMON_VARIABLES`. For example,
+```
+CMAKE_COMMON_VARIABLES="-DPYAPR_USE_OPENMP=OFF -DPYAPR_USE_CUDA=OFF" python setup.py install
+```
+should install the package with both OpenMP and CUDA disabled.
+
+### OpenMP support on OSX
+
+To use the homebrew-installed clang for OpenMP support on OSX, modify the call above to
+```
+CPPFLAGS="-I/usr/local/opt/llvm/include" LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" CXX="/usr/local/opt/llvm/bin/clang++" CC="/usr/local/opt/llvm/bin/clang" python setup.py install 
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,12 +61,14 @@ There are two CMake options that can be given to enable or disable OpenMP and CU
 |:--|:--|:--|
 | PYAPR_USE_OPENMP | Enable multithreading via OpenMP | ON |
 | PYAPR_USE_CUDA | Build available CUDA functionality | OFF |
+| PYAPR_PREFER_EXTERNAL_LIBAPR | Use an installed version of LibAPR (if found) rather than building it from submodules | OFF |
 
-When building via the setup.py script, these options can be set via the environment variable `CMAKE_COMMON_VARIABLES`. For example,
+When building via the setup.py script, these options can be set via the environment variable `EXTRA_CMAKE_ARGS`. For example,
 ```
-CMAKE_COMMON_VARIABLES="-DPYAPR_USE_OPENMP=OFF -DPYAPR_USE_CUDA=OFF" python setup.py install
+EXTRA_CMAKE_ARGS="-DPYAPR_USE_OPENMP=OFF -DPYAPR_USE_CUDA=OFF" python setup.py install
 ```
-should install the package with both OpenMP and CUDA disabled.
+will install the package with both OpenMP and CUDA disabled. If building from an installed version of LibAPR in a non-standard
+location, help CMake find it, e.g., by passing `-DCMAKE_PREFIX_PATH=/path/to/APR`.
 
 ### OpenMP support on OSX
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ Also be sure to check out our (experimental) [napari] plugin: [napari-apr-viewer
 **pyapr** is distributed under the terms of the [Apache Software License 2.0].
 
 
+## Issues
+
+If you encounter any problems, please [file an issue] with a short description. 
+
 ## Contact us
 
-If anything is not working as you think it should, or would like it to, please get in touch with us!! Further, dont 
-hesitate to contact us if you have a project or algorithm you would like to try using the APR for. We would be happy to 
-assist you!
+If you have a project or algorithm in which you would like to try using the APR, don't hesitate to get
+in touch with us. We would be happy to assist you!
 
 
 [LibAPR]: https://github.com/AdaptiveParticles/LibAPR
@@ -62,3 +65,4 @@ assist you!
 [napari]: https://napari.org
 [napari-apr-viewer]: https://github.com/AdaptiveParticles/napari-apr-viewer
 [Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0
+[file an issue]: https://github.com/AdaptiveParticles/PyLibAPR/issues

--- a/README.md
+++ b/README.md
@@ -1,20 +1,31 @@
 # PyLibAPR
 
-![build and deploy](https://github.com/AdaptiveParticles/PyLibAPR/actions/workflows/main.yml/badge.svg)
-![PyPI - Python Version](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue) 
+[![build and deploy](https://github.com/AdaptiveParticles/PyLibAPR/actions/workflows/main.yml/badge.svg)](https://github.com/AdaptiveParticles/PyLibAPR/actions)
+[![License](https://img.shields.io/pypi/l/pyapr.svg?color=green)](https://raw.githubusercontent.com/AdaptiveParticles/PyLibAPR/master/LICENSE)
+[![Python Version](https://img.shields.io/pypi/pyversions/pyapr.svg?color=blue)]((https://python.org))
+[![PyPI](https://img.shields.io/pypi/v/pyapr.svg?color=green)](https://pypi.org/project/pyapr/)
 ![PowerShell Gallery](https://img.shields.io/powershellgallery/p/DNS.1.1.1.1)
 
-Python wrappers for [LibAPR](https://github.com/AdaptiveParticles/LibAPR) - Library for producing and processing on 
-the Adaptive Particle Representation (APR).
+Python wrappers for [LibAPR]: A library for producing and processing on the Adaptive Particle Representation (APR).
 
-For article see: https://www.nature.com/articles/s41467-018-07390-9
+The APR is an adaptive image representation designed primarily for large volumetric
+microscopy datasets. By replacing pixels with particles positioned according to the
+image content, it enables orders-of-magnitude compression of sparse image data
+while maintaining image quality. However, unlike most compression formats, the APR
+can be used directly in a wide range of processing tasks - even on the GPU!
 
-## Installation using PYPI
-For Windows 10, OSX, and Linux and Python versions 3.6-3.9 direct installation with OpenMP support should work via:
+For more detailed information about the APR and its use, see:
+- [Adaptive particle representation of fluorescence microscopy images](https://www.nature.com/articles/s41467-018-07390-9) (nature communications)
+- [Parallel Discrete Convolutions on Adaptive Particle Representations of Images](https://arxiv.org/abs/2112.03592) (arXiv preprint)
+
+## Installation
+For Windows 10, OSX, and Linux and Python versions 3.7-3.9 direct installation with OpenMP support should work via [pip]:
 ```
 pip install pyapr
 ```
 Note: Due to the use of OpenMP, it is encouraged to install as part of a virtualenv.
+
+See [INSTALL] for manual build instructions.
 
 ## Exclusive features
 
@@ -27,89 +38,27 @@ new features that simplify the generation and handling of the APR. For example:
 * Interactive APR raycast (maximum intensity projection) viewer (see [raycast_demo](demo/raycast_demo.py))
 * Interactive lossy compression of particle intensities (see [compress_particles_demo](demo/compress_particles_demo.py))
 
-For further instructions see: https://github.com/AdaptiveParticles/PyLibAPR/tree/master/demo
+For further examples see the [demo scripts].
 
-# Developer Instructions
+Also be sure to check out our (experimental) [napari] plugin: [napari-apr-viewer].
 
-## Dependencies
 
-[LibAPR](https://github.com/AdaptiveParticles/LibAPR) is included as a submodule, and built alongside the wrappers. 
-This requires the following packages:
+## License
 
-* HDF5 1.8.20 or higher
-* OpenMP > 3.0 (optional, but recommended)
-* CMake 3.6 or higher
-* LibTIFF 4.0 or higher
+**pyapr** is distributed under the terms of the [Apache Software License 2.0].
 
-The Python library additionally requires Python 3, and the packages listed in [requirements.txt](requirements.txt).
-
-### Installing dependencies on Linux
-
-On Ubuntu, install the `cmake`, `build-essential`, `libhdf5-dev` and `libtiff5-dev` packages (on other distributions, 
-refer to the documentation there, the package names will be similar). OpenMP support is provided by the GCC compiler 
-installed as part of the `build-essential` package.
-
-### Installing dependencies on OSX
-
-On OSX, install the `cmake`, `hdf5` and `libtiff`  [homebrew](https://brew.sh) packages and have the 
-[Xcode command line tools](http://osxdaily.com/2014/02/12/install-command-line-tools-mac-os-x/) installed.
-If you want to compile with OpenMP support, also install the `llvm` package (this can also be done using homebrew), 
-as the clang version shipped by Apple currently does not support OpenMP.
-
-### Note for windows users
-
-Please see https://github.com/AdaptiveParticles/LibAPR for the latest windows install instructions.
-
-## Building
-
-The repository requires submodules, so the repository needs to be cloned recursively:
-
-```
-git clone --recursive https://github.com/AdaptiveParticles/PyLibAPR.git
-```
-
-It is recommended to use a virtual environment, such as `virtualenv`. To set this up, use e.g.
-
-```
-pip3 install virtualenv
-python3 -m virtualenv myenv
-source myenv/bin/activate
-```
-
-The required Python packages can be installed via the command
-```
-pip install -r requirements.txt 
-```
-
-Once the dependencies are installed, PyLibAPR can be built via the setup.py script:
-```
-python setup.py install
-```
-
-### CMake build options
-
-There are two CMake options that can be given to enable or disable OpenMP and CUDA:
-
-| Option | Description | Default value |
-|:--|:--|:--|
-| PYAPR_USE_OPENMP | Enable multithreading via OpenMP | ON |
-| PYAPR_USE_CUDA | Build available CUDA functionality | OFF |
-
-When building via the setup.py script, these options can be set via the environment variable `CMAKE_COMMON_VARIABLES`. For example,
-```
-CMAKE_COMMON_VARIABLES="-DPYAPR_USE_OPENMP=OFF -DPYAPR_USE_CUDA=OFF" python setup.py install
-```
-should install the package with both OpenMP and CUDA disabled.
-
-### OpenMP support on OSX
-
-To use the homebrew-installed clang for OpenMP support on OSX, modify the call above to
-```
-CPPFLAGS="-I/usr/local/opt/llvm/include" LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" CXX="/usr/local/opt/llvm/bin/clang++" CC="/usr/local/opt/llvm/bin/clang" python setup.py install 
-```
 
 ## Contact us
 
 If anything is not working as you think it should, or would like it to, please get in touch with us!! Further, dont 
 hesitate to contact us if you have a project or algorithm you would like to try using the APR for. We would be happy to 
 assist you!
+
+
+[LibAPR]: https://github.com/AdaptiveParticles/LibAPR
+[pip]: https://pypi.org/project/pip/
+[INSTALL]: INSTALL.md
+[demo scripts]: demo
+[napari]: https://napari.org
+[napari-apr-viewer]: https://github.com/AdaptiveParticles/napari-apr-viewer
+[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0

--- a/fix_windows_wheel.py
+++ b/fix_windows_wheel.py
@@ -17,17 +17,7 @@ def main(wheel_file, dest_dir):
     #unpack the wheel
     subprocess.check_call(['wheel', 'unpack', wheel_name])
 
-    folders = glob.glob('pyapr*/')    # there should be only one
-    print('unpacked folders:')
-    print(folders)
-
-    folder = folders[0]
-
-    print('unpacked wheel folder contents:')
-    print(os.listdir(folder))
-
-    print('contents of Release:')
-    print(os.listdir(os.path.join(folder, 'Release')))
+    folder = glob.glob('pyapr*/')[0]    # there should be only one
 
     # copy files out of the Release subdirectory
     files_2_copy = glob.glob(os.path.join(folder, 'Release', '*'))
@@ -37,9 +27,6 @@ def main(wheel_file, dest_dir):
 
     # remove the Release folder and its contents
     shutil.rmtree(os.path.join(folder, 'Release'))
-
-    print('folder contents after copy:')
-    print(os.listdir(folder))
 
     # repack the wheel
     subprocess.check_call(['wheel', 'pack', folder])

--- a/fix_windows_wheel.py
+++ b/fix_windows_wheel.py
@@ -17,17 +17,29 @@ def main(wheel_file, dest_dir):
     #unpack the wheel
     subprocess.check_call(['wheel', 'unpack', wheel_name])
 
-    folder = glob.glob('pyapr*/')[0]    # there should be only one
+    folders = glob.glob('pyapr*/')    # there should be only one
+    print('unpacked folders:')
+    print(folders)
+
+    folder = folders[0]
+
+    print('unpacked wheel folder contents:')
+    print(os.listdir(folder))
+
+    print('contents of Release:')
+    print(os.listdir(os.path.join(folder, 'Release')))
 
     # copy files out of the Release subdirectory
-    path = os.path.join(folder, 'Release', '*')
-    files_2_copy = glob.glob(path)
+    files_2_copy = glob.glob(os.path.join(folder, 'Release', '*'))
     for fc in files_2_copy:
-        print(fc)
+        print('copying file ', fc, ' to ', folder)
         shutil.copy(fc,folder)
 
     # remove the Release folder and its contents
     shutil.rmtree(os.path.join(folder, 'Release'))
+
+    print('folder contents after copy:')
+    print(os.listdir(folder))
 
     # repack the wheel
     subprocess.check_call(['wheel', 'pack', folder])

--- a/pyapr/__init__.py
+++ b/pyapr/__init__.py
@@ -1,25 +1,7 @@
-"""Python wrappers for LibAPR
-
-The main package of pyapr contains no features. These are instead available through the following subpackages:
-
-Subpackages
------------
-
-data_containers
-    fundamental data container classes
-
-converter
-    templated classes for creating APRs from images of different data types
-
-io
-    reading and writing APRs from/to file
-
-numerics
-    subpackage for processing using APRs
-
-viewer
-    a simple graphical user interface for visualizing results and exploring parameters
-"""
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "not-installed"
 
 from . import data_containers
 from .data_containers import *
@@ -29,4 +11,4 @@ from . import io
 from . import numerics
 from . import viewer
 
-__all__ = ['data_containers', 'io', 'viewer', 'converter', 'numerics', 'tests']
+__all__ = ['data_containers', 'io', 'viewer', 'converter', 'numerics']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,3 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 
 [tool.setuptools_scm]
 write_to = "pyapr/_version.py"
-
-[tool.cibuildwheel]
-test-command = "python -W default -m unittest discover -s {project}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,4 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 write_to = "pyapr/_version.py"
 
 [tool.cibuildwheel]
-test-command = "python3 -m unittest discover"
+test-command = "python -W default -m unittest discover -s {project}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+
+[tool.setuptools_scm]
+write_to = "pyapr/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,6 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 
 [tool.setuptools_scm]
 write_to = "pyapr/_version.py"
+
+[tool.cibuildwheel]
+test-command = "python3 -m unittest discover"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ numpy
 scikit-image
 tifffile
 PyQt5
-pyqtgraph==0.12.1
+pyqtgraph
 matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,28 @@
+[metadata]
+name = pyapr
+author = Joel Jonsson, Bevan Cheeseman
+author_email = jonsson@mpi-cbg.de
+description = Python wrappers for LibAPR
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/AdaptiveParticles/PyLibAPR
+license = Apache-2.0
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python ::
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+zip_safe = False
+packages = find:
+install_requires =
+    numpy
+    scikit-image
+    PyQt5
+    pyqtgraph
+    tifffile
+    matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python ::
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,9 @@ setup(
         'Development Status :: 1 - Planning',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='LibAPR, PyLibAPR, APR',
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         'numpy',
         'scikit-image',
         'PyQt5',
-        'pyqtgraph==0.12.1',
+        'pyqtgraph',
         'matplotlib'
     ],
     description='Python wrappers for LibAPR',

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@
 import os
 import sys
 import subprocess
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
+
 
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
@@ -80,34 +81,11 @@ class CMakeBuild(build_ext):
             ["cmake", "--build", ".", "--parallel", "4"] + build_args, cwd=self.build_temp
         )
 
+
+
 setup(
-    name='pyapr',
     ext_modules=[CMakeExtension('_pyaprwrapper')],
     cmdclass={
         'build_ext': CMakeBuild,
-    },
-    packages=find_packages(),
-    install_requires=[
-        'numpy',
-        'scikit-image',
-        'PyQt5',
-        'pyqtgraph',
-        'matplotlib'
-    ],
-    description='Python wrappers for LibAPR',
-    long_description="long_description",
-    url='https://github.com/joeljonsson/PyLibAPR',
-    author='Joel Jonsson, Bevan Cheeseman',
-    author_email='jonsson@mpi-cbg.de',
-    license='Apache-2.0',
-    classifiers=[
-        'Development Status :: 1 - Planning',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-    ],
-    keywords='LibAPR, PyLibAPR, APR',
-    zip_safe=False
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,6 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pyapr',
-
-    version='0.0.0.4',
     ext_modules=[CMakeExtension('_pyaprwrapper')],
     cmdclass={
         'build_ext': CMakeBuild,


### PR DESCRIPTION
I've set us up to use [setuptools_scm](https://github.com/pypa/setuptools_scm) for versioning based on tags. Currently it gives the version `0.1.dev483+...` as we have no tags and 483 commits. We should then start adding git tags according to [semver](https://semver.org/). 

We should also modify the github actions workflow to take this into account. Currently, it tries to upload any push or pull request to master/develop to pypi (though nothing actually gets uploaded unless the version is bumped). However, with these changes the version is changed automatically, so unintentional uploads are likely to happen. My suggestion would be to build and test on push/pr, but only deploy on tag events. 