### PR TITLE
Explicit type management for conversion/sampling methods

### DIFF
--- a/demo/apr_io_demo.py
+++ b/demo/apr_io_demo.py
@@ -3,62 +3,37 @@ import numpy as np
 from skimage import io as skio
 
 
-def main():
-    """
-    This demo converts a selected TIFF image to an APR, writes the result to file and then reads the file.
-    """
+"""
+This demo converts a selected TIFF image to an APR, writes the result to file and then reads the file.
+"""
 
-    io_int = pyapr.filegui.InteractiveIO()
+io_int = pyapr.filegui.InteractiveIO()
 
-    # Read in an image
-    fpath = io_int.get_tiff_file_name()
-    img = skio.imread(fpath).astype(np.uint16)
+# Read in an image
+fpath = io_int.get_tiff_file_name()
+img = skio.imread(fpath).astype(np.uint16)
 
-    # Instantiate objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()
-    par = pyapr.APRParameters()
-    converter = pyapr.converter.ShortConverter()
+# convert image to APR (with default parameters)
+apr, parts = pyapr.converter.get_apr(img)
 
-    # Set some parameters
-    par.auto_parameters = False
-    par.rel_error = 0.1
-    par.Ip_th = 10
-    par.grad_th = 1
-    par.gradient_smoothing = 2
-    par.sigma_th = 20
-    par.sigma_th_max = 10
-    converter.set_parameters(par)
-    converter.verbose = False
+# Compute and display the computational ratio
+numParts = apr.total_number_particles()
+numPix = img.size
+cr = numPix / numParts
+print('Input image size: {} pixels, APR size: {} particles --> Computational Ratio = {}'.format(numPix, numParts, cr))
 
-    # Compute APR and sample particle values
-    converter.get_apr(apr, img)
-    parts.sample_image(apr, img)
+# Save the APR to file
+fpath_apr = io_int.save_apr_file_name()  # get save path from gui
+pyapr.io.write(fpath_apr, apr, parts)    # write apr and particles to file
 
-    # Compute and display the computational ratio
-    numParts = apr.total_number_particles()
-    numPix = img.size
-    cr = numPix / numParts
-    print('Input image size: {} pixels, APR size: {} particles --> Computational Ratio: {}'.format(numPix, numParts, cr))
+# Read the newly written file
+apr2, parts2 = pyapr.io.read(fpath_apr)
 
-    # Save the APR to file
-    fpath_apr = io_int.save_apr_file_name()  # get save path from gui
-    pyapr.io.write(fpath_apr, apr, parts)    # write apr and particles to file
+# check that particles are equal at a single, random index
+ri = np.random.randint(0, numParts-1)
+assert parts[ri] == parts2[ri]
 
-    # Read the newly written file
-    apr2 = pyapr.APR()
-    parts2 = pyapr.ShortParticles()
-    pyapr.io.read(fpath_apr, apr2, parts2)
-
-    # check that particles are equal at a single, random index
-    ri = np.random.randint(0, numParts-1)
-    assert parts[ri] == parts2[ri]
-
-    # check some APR properties
-    assert apr.total_number_particles() == apr2.total_number_particles()
-    assert apr.level_max() == apr2.level_max()
-    assert apr.level_min() == apr2.level_min()
-
-
-if __name__ == '__main__':
-    main()
+# check some APR properties
+assert apr.total_number_particles() == apr2.total_number_particles()
+assert apr.level_max() == apr2.level_max()
+assert apr.level_min() == apr2.level_min()

--- a/demo/apr_io_demo.py
+++ b/demo/apr_io_demo.py
@@ -11,7 +11,7 @@ io_int = pyapr.filegui.InteractiveIO()
 
 # Read in an image
 fpath = io_int.get_tiff_file_name()
-img = skio.imread(fpath).astype(np.uint16)
+img = skio.imread(fpath)
 
 # convert image to APR (with default parameters)
 apr, parts = pyapr.converter.get_apr(img)

--- a/demo/apr_iteration_demo.py
+++ b/demo/apr_iteration_demo.py
@@ -3,78 +3,70 @@ import numpy as np
 from time import time
 
 
-def main():
-    """
-    This demo implements a piecewise constant reconstruction using the wrapped PyLinearIterator. The Python reconstruction
-    is timed and compared to the internal C++ version.
+"""
+This demo implements a piecewise constant reconstruction using the wrapped PyLinearIterator. The Python reconstruction
+is timed and compared to the internal C++ version.
 
-    Note: The current Python reconstruction is very slow and needs to be improved. For now, this demo is best used as a
-    coding example of the loop structure to access particles and their spatial properties.
-    """
+Note: The current Python reconstruction is very slow and needs to be improved. For now, this demo is best used as a
+coding example of the loop structure to access particles and their spatial properties.
+"""
 
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()  # get APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()  # get APR file path from gui
 
-    # Instantiate APR and particle objects
-    parts = pyapr.ShortParticles()
-    apr = pyapr.APR()
+# Read from APR file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read from APR file
-    pyapr.io.read(fpath_apr, apr, parts)
+# Illustrates the usage of the Python-wrapped linear iterator by computing the piecewise constant reconstruction
+start = time()
+py_recon = np.empty(apr.shape())
+max_level = apr.level_max()
 
-    # Illustrates the usage of the Python-wrapped linear iterator by computing the piecewise constant reconstruction
-    start = time()
-    py_recon = np.empty((apr.org_dims(2), apr.org_dims(1), apr.org_dims(0)), dtype=np.uint16)
-    max_level = apr.level_max()
+apr_it = apr.iterator()  # LinearIterator
 
-    apr_it = apr.iterator()  # LinearIterator
+# particles at the maximum level coincide with pixels
+level = max_level
+for z in range(apr_it.z_num(level)):
+    for x in range(apr_it.x_num(level)):
+        for idx in range(apr_it.begin(level, z, x), apr_it.end()):
+            py_recon[z, x, apr_it.y(idx)] = parts[idx]
 
-    # particles at the maximum level coincide with pixels
-    level = max_level
+# loop over levels up to level_max-1
+for level in range(apr_it.level_min(), apr_it.level_max()):
+
+    step_size = 2 ** (max_level - level)    # this is the size (in pixels) of the particle cells at level
+
     for z in range(apr_it.z_num(level)):
         for x in range(apr_it.x_num(level)):
             for idx in range(apr_it.begin(level, z, x), apr_it.end()):
-                py_recon[z, x, apr_it.y(idx)] = parts[idx]
+                y = apr_it.y(idx)
 
-    # loop over levels up to level_max-1
-    for level in range(apr_it.level_min(), apr_it.level_max()):
+                y_start = y * step_size
+                x_start = x * step_size
+                z_start = z * step_size
 
-        step_size = 2 ** (max_level - level)    # this is the size (in pixels) of the particle cells at level
+                y_end = min(y_start+step_size, py_recon.shape[2])
+                x_end = min(x_start+step_size, py_recon.shape[1])
+                z_end = min(z_start+step_size, py_recon.shape[0])
 
-        for z in range(apr_it.z_num(level)):
-            for x in range(apr_it.x_num(level)):
-                for idx in range(apr_it.begin(level, z, x), apr_it.end()):
-                    y = apr_it.y(idx)
+                py_recon[z_start:z_end, x_start:x_end, y_start:y_end] = parts[idx]
 
-                    y_start = y * step_size
-                    x_start = x * step_size
-                    z_start = z * step_size
+py_time = time()-start
+print('python reconstruction took {} seconds'.format(py_time))
 
-                    y_end = min(y_start+step_size, py_recon.shape[2])
-                    x_end = min(x_start+step_size, py_recon.shape[1])
-                    z_end = min(z_start+step_size, py_recon.shape[0])
+# Compare to the c++ reconstruction
+start = time()
+cpp_recon = pyapr.numerics.reconstruction.reconstruct_constant(apr, parts)
+cpp_time = time()-start
+print('c++ reconstruction took {} seconds'.format(cpp_time))
+print('c++ was {} times faster'.format(py_time / cpp_time))
 
-                    py_recon[z_start:z_end, x_start:x_end, y_start:y_end] = parts[idx]
+# check that both methods produce the same results (on a subset of the image if it is larger than 128^3 pixels)
+zm = min(apr.org_dims(2), 128)
+xm = min(apr.org_dims(1), 128)
+ym = min(apr.org_dims(0), 128)
 
-    py_time = time()-start
-    print('python reconstruction took {} seconds'.format(py_time))
+success = np.allclose(py_recon[:zm, :xm, :ym], cpp_recon[:zm, :xm, :ym])
+if not success:
+    print('Python and C++ reconstructions seem to give different results...')
 
-    # Compare to the c++ reconstruction
-    start = time()
-    cpp_recon = pyapr.numerics.reconstruction.reconstruct_constant(apr, parts)
-    cpp_time = time()-start
-    print('c++ reconstruction took {} seconds'.format(cpp_time))
-    print('c++ was {} times faster'.format(py_time / cpp_time))
-
-    # check that both methods produce the same results (on a subset of the image if it is larger than 128^3 pixels)
-    zm = min(apr.org_dims(2), 128)
-    xm = min(apr.org_dims(1), 128)
-    ym = min(apr.org_dims(0), 128)
-
-    success = np.allclose(py_recon[:zm, :xm, :ym], cpp_recon[:zm, :xm, :ym])
-    if not success:
-        print('Python and C++ reconstructions seem to give different results...')
-
-
-if __name__ == '__main__':
-    main()

--- a/demo/apr_segmentation_demo.py
+++ b/demo/apr_segmentation_demo.py
@@ -1,74 +1,64 @@
 import pyapr
 
 
-def main():
-    """
-    This demo performs graph cut segmentation using maxflow-v3.04 (http://pub.ist.ac.at/~vnk/software.html)
-    by Yuri Boykov and Vladimir Kolmogorov.
+"""
+This demo performs graph cut segmentation using maxflow-v3.04 (http://pub.ist.ac.at/~vnk/software.html)
+by Yuri Boykov and Vladimir Kolmogorov.
 
-    The graph is formed by linking each particle to its face-side neighbours in each dimension.
-    Terminal edge costs are set based on a smoothed local minimum and the local standard deviation, while
-    neighbour edge costs are set based on intensity difference, resolution level and local standard deviation.
+The graph is formed by linking each particle to its face-side neighbours in each dimension.
+Terminal edge costs are set based on a smoothed local minimum and the local standard deviation, while
+neighbour edge costs are set based on intensity difference, resolution level and local standard deviation.
 
-    Note: experimental!
-    """
+Note: experimental!
+"""
 
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()  # get APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()  # get APR file path from gui
 
-    # Instantiate APR and particle objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()  # input particles can be float32 or uint16
-    # parts = pyapr.FloatParticles()
+# Read from APR file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read from APR file
-    pyapr.io.read(fpath_apr, apr, parts)
+# output must be short (uint16)
+mask = pyapr.ShortParticles()
 
-    # output must be short (uint16)
-    mask = pyapr.ShortParticles()
+# parameters affecting memory usage
+avg_num_neighbours = 3.2            # controls the amount of memory initially allocated for edges.
+#                                     if memory is being reallocated, consider increasing this value
+z_block_size = 64                   # tiled version only: process chunks of this many z-slices
+z_ghost_size = 16                   # tiled version only: use this many "ghost slices" on each side of the chunks
 
-    # parameters affecting memory usage
-    avg_num_neighbours = 3.2            # controls the amount of memory initially allocated for edges.
-    #                                     if memory is being reallocated, consider increasing this value
-    z_block_size = 64                   # tiled version only: process chunks of this many z-slices
-    z_ghost_size = 16                   # tiled version only: use this many "ghost slices" on each side of the chunks
+# parameters affecting the edge costs
+alpha = 5.0                         # scaling factor for terminal edges
+beta = 3.0                          # scaling factor for neighbour edges
 
-    # parameters affecting the edge costs
-    alpha = 5.0                         # scaling factor for terminal edges
-    beta = 3.0                          # scaling factor for neighbour edges
+# parameters affecting the "local minimum" computation
+num_tree_smooth = 3                 # number of "neighbour smoothing" iterations to perform on tree particles
+push_depth = 1                      # high-resolution nodes take their values from push_depth levels coarser nodes
+num_part_smooth = 3                 # number of "neighbour smoothing" iterations to perform on the APR particles
 
-    # parameters affecting the "local minimum" computation
-    num_tree_smooth = 3                 # number of "neighbour smoothing" iterations to perform on tree particles
-    push_depth = 1                      # high-resolution nodes take their values from push_depth levels coarser nodes
-    num_part_smooth = 3                 # number of "neighbour smoothing" iterations to perform on the APR particles
+# additional parameters affecting the costs
+intensity_threshold = 0             # lower threshold on absolute intensity
+std_window_size = 9                 # size of the window used to compute the local standard deviation
+min_var = 30                        # both terminal costs are set to 0 in regions with std lower than this value
+num_levels = 2                      # terminal costs are only set for the num_levels finest resolution particles
+max_factor = 3.0                    # particles brighter than "local_min + max_factor * local_std" are considered foreground
 
-    # additional parameters affecting the costs
-    intensity_threshold = 0             # lower threshold on absolute intensity
-    std_window_size = 9                 # size of the window used to compute the local standard deviation
-    min_var = 30                        # both terminal costs are set to 0 in regions with std lower than this value
-    num_levels = 2                      # terminal costs are only set for the num_levels finest resolution particles
-    max_factor = 3.0                    # particles brighter than "local_min + max_factor * local_std" are considered foreground
+# Compute graphcut segmentation
+pyapr.numerics.segmentation.graphcut(apr, parts, mask, alpha=alpha, beta=beta, avg_num_neighbours=avg_num_neighbours,
+                                     num_tree_smooth=num_tree_smooth, num_part_smooth=num_part_smooth, push_depth=push_depth,
+                                     intensity_threshold=intensity_threshold, min_var=min_var, std_window_size=std_window_size,
+                                     max_factor=max_factor, num_levels=num_levels)
 
-    # Compute graphcut segmentation
-    pyapr.numerics.segmentation.graphcut(apr, parts, mask, alpha=alpha, beta=beta, avg_num_neighbours=avg_num_neighbours,
-                                         num_tree_smooth=num_tree_smooth, num_part_smooth=num_part_smooth, push_depth=push_depth,
-                                         intensity_threshold=intensity_threshold, min_var=min_var, std_window_size=std_window_size,
-                                         max_factor=max_factor, num_levels=num_levels)
+# If you run out of memory, try using this version
+# pyapr.numerics.segmentation.graphcut_tiled(apr, parts, mask, alpha=alpha, beta=beta, avg_num_neighbours=avg_num_neighbours,
+#                                            z_block_size=z_block_size, z_ghost_size=z_ghost_size, num_tree_smooth=num_tree_smooth,
+#                                            num_part_smooth=num_part_smooth, push_depth=push_depth, intensity_threshold=intensity_threshold,
+#                                            min_var=min_var, std_window_size=std_window_size,
+#                                            max_factor=max_factor, num_levels=num_levels)
 
-    # If you run out of memory, try using this version
-    # pyapr.numerics.segmentation.graphcut_tiled(apr, parts, mask, alpha=alpha, beta=beta, avg_num_neighbours=avg_num_neighbours,
-    #                                            z_block_size=z_block_size, z_ghost_size=z_ghost_size, num_tree_smooth=num_tree_smooth,
-    #                                            num_part_smooth=num_part_smooth, push_depth=push_depth, intensity_threshold=intensity_threshold,
-    #                                            min_var=min_var, std_window_size=std_window_size,
-    #                                            max_factor=max_factor, num_levels=num_levels)
+# Display the result
+pyapr.viewer.parts_viewer(apr, mask)
 
-    # Display the result
-    pyapr.viewer.parts_viewer(apr, mask)
-
-    # Save the result to hdf5
-    save_path = io_int.save_apr_file_name()
-    pyapr.io.write(save_path, apr, mask)
-
-
-if __name__ == '__main__':
-    main()
+# Save the result to hdf5
+save_path = io_int.save_apr_file_name()
+pyapr.io.write(save_path, apr, mask)

--- a/demo/compress_particles_demo.py
+++ b/demo/compress_particles_demo.py
@@ -2,43 +2,34 @@ import os
 import pyapr
 
 
-def main():
-    """
-    This demo applies lossy compression to the particle intensities, with the background level and quantization factor
-    set interactively.
-    """
+"""
+This demo applies lossy compression to the particle intensities, with the background level and quantization factor
+set interactively.
+"""
 
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()  # get APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()  # get APR file path from gui
 
-    # Instantiate objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()
+# Read APR and particles from file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read APR and particles from file
-    pyapr.io.read(fpath_apr, apr, parts)
+# Interactive WNL compression
+pyapr.viewer.interactive_compression(apr, parts)
 
-    # Interactive WNL compression
-    pyapr.viewer.interactive_compression(apr, parts)
+# Write compressed APR to file
+fpath_apr_save = io_int.save_apr_file_name()  # get file path from gui
+pyapr.io.write(fpath_apr_save, apr, parts)
 
-    # Write compressed APR to file
-    fpath_apr_save = io_int.save_apr_file_name()  # get file path from gui
-    pyapr.io.write(fpath_apr_save, apr, parts)
+# Size of original and compressed APR files in MB
+original_file_size = os.path.getsize(fpath_apr) * 1e-6
+compressed_file_size = os.path.getsize(fpath_apr_save) * 1e-6
 
-    # Size of original and compressed APR files in MB
-    original_file_size = os.path.getsize(fpath_apr) * 1e-6
-    compressed_file_size = os.path.getsize(fpath_apr_save) * 1e-6
+# Uncompressed pixel image size (assuming 16-bit datatype)
+original_image_size = 2e-6 * apr.x_num(apr.level_max()) * apr.y_num(apr.level_max()) * apr.z_num(apr.level_max())
 
-    # Uncompressed pixel image size (assuming 16-bit datatype)
-    original_image_size = 2e-6 * apr.x_num(apr.level_max()) * apr.y_num(apr.level_max()) * apr.z_num(apr.level_max())
+print("Original APR File Size: {:7.2f} MB".format(original_file_size))
+print("Lossy Compressed APR File Size: {:7.2f} MB".format(compressed_file_size))
 
-    print("Original APR File Size: {:7.2f} MB".format(original_file_size))
-    print("Lossy Compressed APR File Size: {:7.2f} MB".format(compressed_file_size))
-
-    # compare uncompressed pixel image size to compressed APR file sizes
-    print("Original Memory Compression Ratio: {:7.2f} ".format(original_image_size/original_file_size))
-    print("Lossy Memory Compression Ratio: {:7.2f} ".format(original_image_size/compressed_file_size))
-
-
-if __name__ == '__main__':
-    main()
+# compare uncompressed pixel image size to compressed APR file sizes
+print("Original Memory Compression Ratio: {:7.2f} ".format(original_image_size/original_file_size))
+print("Lossy Memory Compression Ratio: {:7.2f} ".format(original_image_size/compressed_file_size))

--- a/demo/convolution_demo.py
+++ b/demo/convolution_demo.py
@@ -1,5 +1,5 @@
 import pyapr
-
+from time import time
 """
 This demo reads an APR, applies a convolution operation and displays the result
 """
@@ -15,16 +15,25 @@ stencil = pyapr.numerics.filter.get_gaussian_stencil(size=5, sigma=1, ndims=3, n
 out = pyapr.FloatParticles()
 
 # Convolve using CPU:
+t0 = time()
 pyapr.numerics.convolve(apr, parts, out, stencil, use_stencil_downsample=True,
                         normalize_stencil=True, use_reflective_boundary=False)
+print('convolve took {} seconds'.format(time()-t0))
 
-# Alternative CPU convolution method (produces the same result as 'convolve'):
-# pyapr.numerics.convolve_pencil(apr, parts, out, stencil, use_stencil_downsample=True,
-#                                normalize_stencil=True, use_reflective_boundary=False)
+
+# Alternative CPU convolution algorithm:
+t0 = time()
+pyapr.numerics.convolve_pencil(apr, parts, out, stencil, use_stencil_downsample=True,
+                               normalize_stencil=True, use_reflective_boundary=False)
+print('convolve_pencil took {} seconds'.format(time()-t0))
+
 
 # Convolve using GPU (stencil must be of shape 3x3x3 or 5x5x5):
-# pyapr.numerics.convolve_cuda(apr, parts, out, stencil, use_stencil_downsample=True,
-#                          normalize_stencil=True, use_reflective_boundary=False)
+if pyapr.cuda_build() and stencil.shape in [(3, 3, 3), (5, 5, 5)]:
+    t0 = time()
+    pyapr.numerics.convolve_cuda(apr, parts, out, stencil, use_stencil_downsample=True,
+                                 normalize_stencil=True, use_reflective_boundary=False)
+    print('convolve_cuda took {} seconds'.format(time()-t0))
 
 # Display the result
 pyapr.viewer.parts_viewer(apr, out)

--- a/demo/convolution_demo.py
+++ b/demo/convolution_demo.py
@@ -29,7 +29,7 @@ print('convolve_pencil took {} seconds'.format(time()-t0))
 
 
 # Convolve using GPU (stencil must be of shape 3x3x3 or 5x5x5):
-if pyapr.cuda_build() and stencil.shape in [(3, 3, 3), (5, 5, 5)]:
+if pyapr.cuda_enabled() and stencil.shape in [(3, 3, 3), (5, 5, 5)]:
     t0 = time()
     pyapr.numerics.convolve_cuda(apr, parts, out, stencil, use_stencil_downsample=True,
                                  normalize_stencil=True, use_reflective_boundary=False)

--- a/demo/convolution_demo.py
+++ b/demo/convolution_demo.py
@@ -1,41 +1,30 @@
 import pyapr
 
+"""
+This demo reads an APR, applies a convolution operation and displays the result
+"""
 
-def main():
-    """
-    This demo reads an APR, applies a convolution operation and displays the result
-    """
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()  # get APR file path from gui
 
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()  # get APR file path from gui
+# Read from APR file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Instantiate APR and particle objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()      # input particles can be float32 or uint16
-    # parts = pyapr.FloatParticles()
+# Stencil and output must be float32
+stencil = pyapr.numerics.filter.get_gaussian_stencil(size=5, sigma=1, ndims=3, normalize=True)
+out = pyapr.FloatParticles()
 
-    # Read from APR file
-    pyapr.io.read(fpath_apr, apr, parts)
+# Convolve using CPU:
+pyapr.numerics.convolve(apr, parts, out, stencil, use_stencil_downsample=True,
+                        normalize_stencil=True, use_reflective_boundary=False)
 
-    # Stencil and output must be float32
-    stencil = pyapr.numerics.filter.get_gaussian_stencil(size=5, sigma=1, ndims=3, normalize=True)
-    out = pyapr.FloatParticles()
+# Alternative CPU convolution method (produces the same result as 'convolve'):
+# pyapr.numerics.convolve_pencil(apr, parts, out, stencil, use_stencil_downsample=True,
+#                                normalize_stencil=True, use_reflective_boundary=False)
 
-    # Convolve using CPU:
-    pyapr.numerics.convolve(apr, parts, out, stencil, use_stencil_downsample=True,
-                            normalize_stencil=True, use_reflective_boundary=False)
+# Convolve using GPU (stencil must be of shape 3x3x3 or 5x5x5):
+# pyapr.numerics.convolve_cuda(apr, parts, out, stencil, use_stencil_downsample=True,
+#                          normalize_stencil=True, use_reflective_boundary=False)
 
-    # Alternative CPU convolution method (produces the same result as 'convolve'):
-    # pyapr.numerics.convolve_pencil(apr, parts, out, stencil, use_stencil_downsample=True,
-    #                                normalize_stencil=True, use_reflective_boundary=False)
-
-    # Convolve using GPU (stencil must be of shape 3x3x3 or 5x5x5):
-    # pyapr.numerics.convolve_cuda(apr, parts, out, stencil, use_stencil_downsample=True,
-    #                          normalize_stencil=True, use_reflective_boundary=False)
-
-    # Display the result
-    pyapr.viewer.parts_viewer(apr, out)
-
-
-if __name__ == '__main__':
-    main()
+# Display the result
+pyapr.viewer.parts_viewer(apr, out)

--- a/demo/get_apr_by_block_interactive_demo.py
+++ b/demo/get_apr_by_block_interactive_demo.py
@@ -3,98 +3,93 @@ import pyapr
 import tifffile
 
 
-def main():
-    """
-    Interactive APR conversion of large images. Reads in a block of z-slices for interactive setting of the
-    following parameters:
-        Ip_th       (background intensity level)
-        sigma_th    (local intensity scale threshold)
-        grad_th     (gradient threshold)
+"""
+Interactive APR conversion of large images. Reads in a block of z-slices for interactive setting of the
+following parameters:
+    Ip_th       (background intensity level)
+    sigma_th    (local intensity scale threshold)
+    grad_th     (gradient threshold)
 
-    Use the sliders to control the adaptation. The red overlay shows (approximately) the regions that will be fully
-    resolved (at pixel resolution).
+Use the sliders to control the adaptation. The red overlay shows (approximately) the regions that will be fully
+resolved (at pixel resolution).
 
-    Once the parameters are set, the entire image is processed in overlapping blocks of z-slices. The size of the
-    blocks, and the overlap, can be set in the code below to control the memory consumption.
+Once the parameters are set, the entire image is processed in overlapping blocks of z-slices. The size of the
+blocks, and the overlap, can be set in the code below to control the memory consumption.
 
-    Note: The effect of grad_th may hide the effect of the other thresholds. It is thus recommended to keep grad_th
-    low while setting Ip_th and sigma_th, and then increasing grad_th.
-    """
+Note: The effect of grad_th may hide the effect of the other thresholds. It is thus recommended to keep grad_th
+low while setting Ip_th and sigma_th, and then increasing grad_th.
+"""
 
-    # Read in an image
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath = io_int.get_tiff_file_name()  # get image file path from gui (data type must be float32 or uint16)
+# Read in an image
+io_int = pyapr.filegui.InteractiveIO()
+fpath = io_int.get_tiff_file_name()  # get image file path from gui (data type must be float32 or uint16)
 
-    # Specify the z-range to be used to set the parameters
-    z_start = 0
-    z_end = 256
+# Specify the z-range to be used to set the parameters
+z_start = 0
+z_end = 256
 
-    # Read slice range into numpy array
-    with tifffile.TiffFile(fpath) as tif:
-        img = tif.asarray(key=slice(z_start, z_end))
+# Read slice range into numpy array
+with tifffile.TiffFile(fpath) as tif:
+    img = tif.asarray(key=slice(z_start, z_end))
 
-    # Set some parameters (only Ip_th, grad_th and sigma_th are set interactively)
-    par = pyapr.APRParameters()
-    par.rel_error = 0.1              # relative error threshold
-    par.gradient_smoothing = 3       # b-spline smoothing parameter for gradient estimation
-    #                                  0 = no smoothing, higher = more smoothing
-    par.dx = 1
-    par.dy = 1                       # voxel size
-    par.dz = 1
+# Set some parameters (only Ip_th, grad_th and sigma_th are set interactively)
+par = pyapr.APRParameters()
+par.rel_error = 0.1              # relative error threshold
+par.gradient_smoothing = 3       # b-spline smoothing parameter for gradient estimation
+#                                  0 = no smoothing, higher = more smoothing
+par.dx = 1
+par.dy = 1                       # voxel size
+par.dz = 1
 
-    # Interactively set the threshold parameters using the partial image
-    par = pyapr.converter.find_parameters_interactive(img, params=par, verbose=True, slider_decimals=1)
+# Interactively set the threshold parameters using the partial image
+par = pyapr.converter.find_parameters_interactive(img, params=par, verbose=True, slider_decimals=1)
 
-    del img  # Parameters found, we don't need the partial image anymore
+del img  # Parameters found, we don't need the partial image anymore
 
-    # par.input_dir + par.input_image_name must be the path to the image file
-    par.input_dir = ''
-    par.input_image_name = fpath
+# par.input_dir + par.input_image_name must be the path to the image file
+par.input_dir = ''
+par.input_image_name = fpath
 
-    # Initialize the by-block converter
-    converter = pyapr.converter.ShortConverterBatch()
-    converter.set_parameters(par)
-    converter.verbose = True
+# Initialize the by-block converter
+converter = pyapr.converter.ShortConverterBatch()
+converter.set_parameters(par)
+converter.verbose = True
 
-    # Parameters controlling the memory usage
-    converter.z_block_size = 256    # number of z-slices to process in each block during APR conversion
-    converter.z_ghost_size = 32     # number of ghost slices to use on each side of the blocks
-    block_size_sampling = 256       # block size for sampling of particle intensities
-    ghost_size_sampling = 128       # ghost size for sampling of particle intensities
+# Parameters controlling the memory usage
+converter.z_block_size = 256    # number of z-slices to process in each block during APR conversion
+converter.z_ghost_size = 32     # number of ghost slices to use on each side of the blocks
+block_size_sampling = 256       # block size for sampling of particle intensities
+ghost_size_sampling = 128       # ghost size for sampling of particle intensities
 
-    # Compute the APR
-    apr = pyapr.APR()
-    success = converter.get_apr(apr)
+# Compute the APR
+apr = pyapr.APR()
+success = converter.get_apr(apr)
 
-    if success:
-        cr = apr.computational_ratio()
-        print('APR Conversion successful! Computational ratio (#pixels / #particles) = {}'.format(cr))
+if success:
+    cr = apr.computational_ratio()
+    print('APR Conversion successful! Computational ratio (#pixels / #particles) = {}'.format(cr))
 
-        print('Sampling particle intensity values')
-        parts = pyapr.ShortParticles()
-        parts.sample_image_blocked(apr, fpath, block_size_sampling, ghost_size_sampling)
-        print('Done!')
+    print('Sampling particle intensity values')
+    parts = pyapr.ShortParticles()
+    parts.sample_image_blocked(apr, fpath, block_size_sampling, ghost_size_sampling)
+    print('Done!')
 
-        # View the result in the by-slice viewer
-        pyapr.viewer.parts_viewer(apr, parts)
+    # View the result in the by-slice viewer
+    pyapr.viewer.parts_viewer(apr, parts)
 
-        # Write the resulting APR to file
-        print("Writing APR to file ... \n")
-        fpath_apr = io_int.save_apr_file_name()  # get path through gui
-        pyapr.io.write(fpath_apr, apr, parts)
+    # Write the resulting APR to file
+    print("Writing APR to file ... \n")
+    fpath_apr = io_int.save_apr_file_name()  # get path through gui
+    pyapr.io.write(fpath_apr, apr, parts)
 
-        if fpath_apr:
-            # Display the size of the file
-            file_sz = os.path.getsize(fpath_apr)
-            print("APR File Size: {:7.2f} MB \n".format(file_sz * 1e-6))
+    if fpath_apr:
+        # Display the size of the file
+        file_sz = os.path.getsize(fpath_apr)
+        print("APR File Size: {:7.2f} MB \n".format(file_sz * 1e-6))
 
-            # Compute compression ratio
-            mcr = os.path.getsize(fpath) / file_sz
-            print("Memory Compression Ratio: {:7.2f}".format(mcr))
+        # Compute compression ratio
+        mcr = os.path.getsize(fpath) / file_sz
+        print("Memory Compression Ratio: {:7.2f}".format(mcr))
 
-    else:
-        print('Something went wrong...')
-
-
-if __name__ == '__main__':
-    main()
+else:
+    print('Something went wrong...')

--- a/demo/get_apr_demo.py
+++ b/demo/get_apr_demo.py
@@ -3,54 +3,45 @@ import pyapr
 from skimage import io as skio
 
 
-def main():
-    """
-    This demo shows how to convert an image to an APR using a fixed set of parameters.
-    """
+"""
+This demo shows how to convert an image to APR using a fixed set of parameters.
+"""
 
-    # Read in an image
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath = io_int.get_tiff_file_name()  # get image file path from gui (data type must be float32 or uint16)
-    img = skio.imread(fpath)
+# Read in an image
+io_int = pyapr.filegui.InteractiveIO()
+fpath = io_int.get_tiff_file_name()  # get image file path from gui (data type must be float32 or uint16)
+img = skio.imread(fpath)
 
-    # Set some parameters
-    par = pyapr.APRParameters()
-    par.rel_error = 0.1          # relative error threshold
-    par.gradient_smoothing = 3   # b-spline smoothing parameter for gradient estimation
-    #                              0 = no smoothing, higher = more smoothing
-    par.dx = 1
-    par.dy = 1                   # voxel size
-    par.dz = 1
-    # threshold parameters
-    par.Ip_th = 0                # regions below this intensity are regarded as background
-    par.grad_th = 3              # gradients below this value are set to 0
-    par.sigma_th = 10            # the local intensity scale is clipped from below to this value
-    par.auto_parameters = False  # if true, threshold parameters are set automatically based on histograms
+# Set some parameters
+par = pyapr.APRParameters()
+par.rel_error = 0.1          # relative error threshold
+par.gradient_smoothing = 3   # b-spline smoothing parameter for gradient estimation
+#                              0 = no smoothing, higher = more smoothing
+par.dx = 1
+par.dy = 1                   # voxel size
+par.dz = 1
+# threshold parameters
+par.Ip_th = 0                # regions below this intensity are regarded as background
+par.grad_th = 3              # gradients below this value are set to 0
+par.sigma_th = 10            # the local intensity scale is clipped from below to this value
+par.auto_parameters = True   # if true, 'grad_th' and 'sigma_th' are computed automatically based on histograms
 
-    # Compute APR and sample particle values
-    apr, parts = pyapr.converter.get_apr(img, params=par, verbose=True)
+# Compute APR and sample particle values
+apr, parts = pyapr.converter.get_apr(img, params=par, verbose=True)
 
-    # Compute computational ratio
-    cr = img.size/apr.total_number_particles()
-    print("Compuational Ratio: {:7.2f}".format(cr))
+# Display the APR
+pyapr.viewer.parts_viewer(apr, parts)
 
-    # Display the APR
-    pyapr.viewer.parts_viewer(apr, parts)
+# Write the resulting APR to file
+print("Writing APR to file ... \n")
+fpath_apr = io_int.save_apr_file_name()  # get path through gui
+pyapr.io.write(fpath_apr, apr, parts)
 
-    # Write the resulting APR to file
-    print("Writing APR to file ... \n")
-    fpath_apr = io_int.save_apr_file_name()  # get path through gui
-    pyapr.io.write(fpath_apr, apr, parts)
+if fpath_apr:
+    # Display the size of the file
+    file_sz = os.path.getsize(fpath_apr)
+    print("APR File Size: {:7.2f} MB \n".format(file_sz * 1e-6))
 
-    if fpath_apr:
-        # Display the size of the file
-        file_sz = os.path.getsize(fpath_apr)
-        print("APR File Size: {:7.2f} MB \n".format(file_sz * 1e-6))
-
-        # Compute compression ratio
-        mcr = os.path.getsize(fpath) / file_sz
-        print("Memory Compression Ratio: {:7.2f}".format(mcr))
-
-
-if __name__ == '__main__':
-    main()
+    # Compute compression ratio
+    mcr = os.path.getsize(fpath) / file_sz
+    print("Memory Compression Ratio: {:7.2f}".format(mcr))

--- a/demo/get_apr_interactive_demo.py
+++ b/demo/get_apr_interactive_demo.py
@@ -3,57 +3,52 @@ import pyapr
 from skimage import io as skio
 
 
-def main():
-    """
-    Interactive APR conversion. Reads in a selected TIFF image for interactive setting of the parameters:
-        Ip_th       (background intensity level)
-        sigma_th    (local intensity scale threshold)
-        grad_th     (gradient threshold)
+"""
+Interactive APR conversion. Reads in a selected TIFF image for interactive setting of the parameters:
+    Ip_th       (intensity threshold)
+    sigma_th    (local intensity scale threshold)
+    grad_th     (gradient threshold)
 
-    Use the sliders to control the adaptation. The red overlay shows (approximately) the regions that will be fully
-    resolved (at pixel resolution).
+Use the sliders to control the adaptation. The red overlay shows (approximately) the regions that will be fully
+resolved (at pixel resolution).
 
-    Once the parameters are set, the final steps of the conversion pipeline are applied to produce the APR and sample
-    the particle intensities.
+Once the parameters are set, the final steps of the conversion pipeline are applied to produce the APR and sample
+the particle intensities.
 
-    Note: The effect of grad_th may hide the effect of the other thresholds. It is thus recommended to keep grad_th
-    low while setting Ip_th and sigma_th, and then increasing grad_th.
-    """
+Note: The effect of grad_th may hide the effect of the other thresholds. It is thus recommended to keep grad_th
+low while setting Ip_th and sigma_th, and then increasing grad_th.
+"""
 
-    # Read in an image
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath = io_int.get_tiff_file_name()  # get image file path from gui (data type must be float32 or uint16)
-    img = skio.imread(fpath)
+# Read in an image
+io_int = pyapr.filegui.InteractiveIO()
+fpath = io_int.get_tiff_file_name()  # get image file path from gui (data type must be float32 or uint16)
+img = skio.imread(fpath)
 
-    # Set some parameters (only Ip_th, grad_th and sigma_th are set interactively)
-    par = pyapr.APRParameters()
-    par.rel_error = 0.1              # relative error threshold
-    par.gradient_smoothing = 3       # b-spline smoothing parameter for gradient estimation
-    #                                  0 = no smoothing, higher = more smoothing
-    par.dx = 1
-    par.dy = 1                       # voxel size
-    par.dz = 1
+# Set some parameters (only Ip_th, grad_th and sigma_th are set interactively)
+par = pyapr.APRParameters()
+par.rel_error = 0.1              # relative error threshold
+par.gradient_smoothing = 3       # b-spline smoothing parameter for gradient estimation
+#                                  0 = no smoothing, higher = more smoothing
+par.dx = 1
+par.dy = 1                       # voxel size
+par.dz = 1
 
-    # Compute APR and sample particle values
-    apr, parts = pyapr.converter.get_apr_interactive(img, params=par, verbose=True, slider_decimals=1)
+# Compute APR and sample particle values
+apr, parts = pyapr.converter.get_apr_interactive(img, params=par, verbose=True, slider_decimals=1)
 
-    # Display the APR
-    pyapr.viewer.parts_viewer(apr, parts)
+# Display the APR
+pyapr.viewer.parts_viewer(apr, parts)
 
-    # Write the resulting APR to file
-    print("Writing APR to file ... \n")
-    fpath_apr = io_int.save_apr_file_name()  # get path through gui
-    pyapr.io.write(fpath_apr, apr, parts)
+# Write the resulting APR to file
+print("Writing APR to file ... \n")
+fpath_apr = io_int.save_apr_file_name()  # get path through gui
+pyapr.io.write(fpath_apr, apr, parts)
 
-    if fpath_apr:
-        # Display the size of the file
-        file_sz = os.path.getsize(fpath_apr)
-        print("APR File Size: {:7.2f} MB \n".format(file_sz * 1e-6))
+if fpath_apr:
+    # Display the size of the file
+    file_sz = os.path.getsize(fpath_apr)
+    print("APR File Size: {:7.2f} MB \n".format(file_sz * 1e-6))
 
-        # Compute compression ratio
-        mcr = os.path.getsize(fpath) / file_sz
-        print("Memory Compression Ratio: {:7.2f}".format(mcr))
-
-
-if __name__ == '__main__':
-    main()
+    # Compute compression ratio
+    mcr = os.path.getsize(fpath) / file_sz
+    print("Memory Compression Ratio: {:7.2f}".format(mcr))

--- a/demo/numerics_demo.py
+++ b/demo/numerics_demo.py
@@ -1,36 +1,26 @@
 import pyapr
 
 
-def main():
-    """
-    This demo showcases some of the available numerics functionality on a selected APR
-    """
+"""
+This demo showcases some of the available numerics functionality on a selected APR
+"""
 
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()      # get APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()      # get APR file path from gui
 
-    # Instantiate APR and particle objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()              # input particles can be float32 or uint16
-    # parts = pyapr.FloatParticles()
+# Read from APR file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read from APR file
-    pyapr.io.read(fpath_apr, apr, parts)
+output = pyapr.FloatParticles()
 
-    output = pyapr.FloatParticles()
+# Compute gradient along a dimension (Sobel filter). dimension can be 0, 1 or 2
+pyapr.numerics.gradient(apr, parts, output, dimension=0, delta=1.0, sobel=True)
+pyapr.viewer.parts_viewer(apr, output)   # Display the result
 
-    # Compute gradient along a dimension (Sobel filter). dimension can be 0, 1 or 2
-    pyapr.numerics.gradient(apr, parts, output, dimension=0, delta=1.0, sobel=True)
-    pyapr.viewer.parts_viewer(apr, output)   # Display the result
+# Compute gradient magnitude (central finite differences)
+pyapr.numerics.gradient_magnitude(apr, parts, output, deltas=(1.0, 1.0, 1.0), sobel=False)
+pyapr.viewer.parts_viewer(apr, output)  # Display the result
 
-    # Compute gradient magnitude (central finite differences)
-    pyapr.numerics.gradient_magnitude(apr, parts, output, deltas=(1.0, 1.0, 1.0), sobel=False)
-    pyapr.viewer.parts_viewer(apr, output)  # Display the result
-
-    # Compute local standard deviation around each particle
-    pyapr.numerics.local_std(apr, parts, output, size=(5, 5, 5))
-    pyapr.viewer.parts_viewer(apr, output)  # Display the result
-
-
-if __name__ == '__main__':
-    main()
+# Compute local standard deviation around each particle
+pyapr.numerics.local_std(apr, parts, output, size=(5, 5, 5))
+pyapr.viewer.parts_viewer(apr, output)  # Display the result

--- a/demo/plot_particle_scatter_demo.py
+++ b/demo/plot_particle_scatter_demo.py
@@ -1,41 +1,31 @@
 import pyapr
 
 
-def main():
-    """
-    Read a selected APR from file and display (a rectangular region of) a given z-slice as a point scatter.
-    """
+"""
+Read a selected APR from file and display (a rectangular region of) a given z-slice as a point scatter.
+"""
 
-    # Get APR file path from gui
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()
+# Get APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()
 
-    # Instantiate APR and particles objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()
-    # parts = pyapr.FloatParticles()
+# Read APR and particles from file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read APR and particles from file
-    pyapr.io.read(fpath_apr, apr, parts)
+display = True      # display the result as a python plot?
+save = False        # save resulting plot as an image?
+if save:
+    save_path = io_int.save_tiff_file_name()
 
-    display = True      # display the result as a python plot?
-    save = False        # save resulting plot as an image?
-    if save:
-        save_path = io_int.save_tiff_file_name()
+z = None                       # which slice to display? (default None -> display center slice)
+base_markersize = 1
+markersize_scale_factor = 2    # markersize = base_markersize * particle_size ** markersize_scale_factor
+figsize = None                 # figure size in inches (default None -> determined by xrange, yrange and dpi)
+dpi = 50                       # dots per inch (output image dimensions will be dpi*figsize)
+xrange = (400, 800)            # range of x values to be plotted
+yrange = (400, 800)            # range of y values to be plotted  (if None or out of bounds, the entire range is used)
 
-    z = None                       # which slice to display? (default None -> display center slice)
-    base_markersize = 1
-    markersize_scale_factor = 2    # markersize = base_markersize * particle_size ** markersize_scale_factor
-    figsize = None                 # figure size in inches (default None -> determined by xrange, yrange and dpi)
-    dpi = 50                       # dots per inch (output image dimensions will be dpi*figsize)
-    xrange = (400, 800)            # range of x values to be plotted
-    yrange = (400, 800)            # range of y values to be plotted  (if None or out of bounds, the entire range is used)
-
-    pyapr.viewer.particle_scatter_plot(apr, parts, z=z, markersize_scale_factor=markersize_scale_factor,
-                                       base_markersize=base_markersize, figsize=figsize, dpi=dpi,
-                                       save_path=save_path if save else None, xrange=xrange, yrange=yrange,
-                                       display=display, cmap='viridis')
-
-
-if __name__ == '__main__':
-    main()
+pyapr.viewer.particle_scatter_plot(apr, parts, z=z, markersize_scale_factor=markersize_scale_factor,
+                                   base_markersize=base_markersize, figsize=figsize, dpi=dpi,
+                                   save_path=save_path if save else None, xrange=xrange, yrange=yrange,
+                                   display=display, cmap='viridis')

--- a/demo/raycast_demo.py
+++ b/demo/raycast_demo.py
@@ -1,29 +1,19 @@
 import pyapr
 
 
-def main():
-    """
-    Read a selected APR from file and visualize it via maximum intensity projection.
+"""
+Read a selected APR from file and visualize it via maximum intensity projection.
 
-    Scroll to zoom
-    Click and drag to change the view
-    """
+Scroll to zoom
+Click and drag to change the view
+"""
 
-    # Get input APR file path from gui
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()
+# Get input APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()
 
-    # Instantiate APR and particles objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()
-    # parts = pyapr.FloatParticles()
+# Read APR and particles from file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read APR and particles from file
-    pyapr.io.read(fpath_apr, apr, parts)
-
-    # Launch the raycast viewer
-    pyapr.viewer.raycast_viewer(apr, parts)
-
-
-if __name__ == '__main__':
-    main()
+# Launch the raycast viewer
+pyapr.viewer.raycast_viewer(apr, parts)

--- a/demo/reconstruction_demo.py
+++ b/demo/reconstruction_demo.py
@@ -3,49 +3,36 @@ from skimage import io as skio
 from pyapr.numerics.reconstruction import reconstruct_constant, reconstruct_smooth, reconstruct_level
 
 
-def main():
-    """
-    This demo illustrates three different pixel image reconstruction methods:
+"""
+This demo illustrates three different pixel image reconstruction methods:
 
-        constant      each pixel takes the value of the particle whose cell contains the pixel
-        smooth        additionally smooths regions of coarser resolution to reduce 'blockiness'
-        level         each pixel takes the value of the resolution level of the particle cell it belongs to
-    """
+    constant      each pixel takes the value of the particle whose cell contains the pixel
+    smooth        additionally smooths regions of coarser resolution to reduce 'blockiness'
+    level         each pixel takes the value of the resolution level of the particle cell it belongs to
+"""
 
-    # get input APR file path from gui
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()
+# get input APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()
 
-    # Instantiate APR and particle objects
-    parts = pyapr.ShortParticles()
-    apr = pyapr.APR()
+# Read APR and particles from file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read APR and particles from file
-    pyapr.io.read(fpath_apr, apr, parts)
+pc_recon = reconstruct_constant(apr, parts)     # piecewise constant reconstruction
+smooth_recon = reconstruct_smooth(apr, parts)   # smooth reconstruction
+level_recon = reconstruct_level(apr)            # level reconstruction
 
-    # Compute piecewise constant reconstruction
-    pc_recon = reconstruct_constant(apr, parts)
+# Save the results
+file_name = '.'.join(fpath_apr.split('/')[-1].split('.')[:-1])
 
-    # Compute smooth reconstruction
-    smooth_recon = reconstruct_smooth(apr, parts)
-
-    # Compute level reconstruction
-    level_recon = reconstruct_level(apr)
-
-    # Save the results
-    file_name = fpath_apr.split('/')[-1]
-    file_name = file_name.split('.')[:-1]
-    file_name = '.'.join(file_name)
-
-    save_path = io_int.save_tiff_file_name(file_name + '_reconstruct_const.tif')
+save_path = io_int.save_tiff_file_name(file_name + '_reconstruct_const.tif')
+if save_path:
     skio.imsave(save_path, pc_recon, check_contrast=False)
 
-    save_path = io_int.save_tiff_file_name(file_name + '_reconstruct_smooth.tif')
+save_path = io_int.save_tiff_file_name(file_name + '_reconstruct_smooth.tif')
+if save_path:
     skio.imsave(save_path, smooth_recon, check_contrast=False)
 
-    save_path = io_int.save_tiff_file_name(file_name + '_reconstruct_level.tif')
+save_path = io_int.save_tiff_file_name(file_name + '_reconstruct_level.tif')
+if save_path:
     skio.imsave(save_path, level_recon, check_contrast=False)
-
-
-if __name__ == '__main__':
-    main()

--- a/demo/richardson_lucy_demo.py
+++ b/demo/richardson_lucy_demo.py
@@ -42,7 +42,7 @@ print('RLTV took {} seconds'.format(time()-t0))
 
 # Alternatively, if PyLibAPR is built with CUDA enabled and psf is of size (3, 3, 3) or (5, 5, 5)
 cuda = False
-if pyapr.cuda_build() and psf.shape in [(3, 3, 3), (5, 5, 5)]:
+if pyapr.cuda_enabled() and psf.shape in [(3, 3, 3), (5, 5, 5)]:
     t0 = time()
     output_cuda = pyapr.FloatParticles()
     pyapr.numerics.richardson_lucy_cuda(apr, parts, output_cuda, psf, niter, use_stencil_downsample=True,

--- a/demo/richardson_lucy_demo.py
+++ b/demo/richardson_lucy_demo.py
@@ -1,55 +1,44 @@
 import pyapr
 
 
-def main():
-    """
-    Read a selected APR from file and apply Richardson-Lucy deconvolution
-    """
+"""
+Read a selected APR from file and apply Richardson-Lucy deconvolution
+"""
 
-    # Get input APR file path from gui
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()
+# Get input APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()
 
-    # Instantiate APR and particles objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()
-    # parts = pyapr.FloatParticles()
+# Read from APR file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read from APR file
-    pyapr.io.read(fpath_apr, apr, parts)
+# Copy particles to float
+parts = pyapr.FloatParticles(parts)
 
-    # Copy particles to float
-    fparts = pyapr.FloatParticles()
-    fparts.copy(parts)
+# Add a small offset to the particle values to avoid division by 0
+offset = 1e-5 * parts.max()
+parts += offset
 
-    # Add a small offset to the particle values to avoid division by 0
-    offset = 1e-5 * fparts.max()
-    fparts += offset
+# Display the input image
+pyapr.viewer.parts_viewer(apr, parts)
 
-    # Display the input image
-    pyapr.viewer.parts_viewer(apr, fparts)
+# Specify the PSF and number of iterations
+psf = pyapr.numerics.filter.get_gaussian_stencil(size=5, sigma=1, ndims=3, normalize=True)
+niter = 20
 
-    # Specify the PSF and number of iterations
-    psf = pyapr.numerics.filter.get_gaussian_stencil(size=5, sigma=1, ndims=3, normalize=True)
-    niter = 20
+# Perform richardson-lucy deconvolution
+output = pyapr.FloatParticles()
+pyapr.numerics.richardson_lucy(apr, parts, output, psf, niter, use_stencil_downsample=True,
+                               normalize_stencil=True, resume=False)
 
-    # Perform richardson-lucy deconvolution
-    output = pyapr.FloatParticles()
-    pyapr.numerics.richardson_lucy(apr, fparts, output, psf, niter, use_stencil_downsample=True,
-                                   normalize_stencil=True, resume=False)
+# Alternative using total variation regularization:
+# reg_factor = 1e-2
+# pyapr.numerics.richardson_lucy_tv(apr, fparts, output, psf, niter, reg_factor, use_stencil_downsample=True,
+#                                   normalize_stencil=True, resume=False)
 
-    # Alternative using total variation regularization:
-    # reg_factor = 1e-2
-    # pyapr.numerics.richardson_lucy_tv(apr, fparts, output, psf, niter, reg_factor, use_stencil_downsample=True,
-    #                                   normalize_stencil=True, resume=False)
+# Alternatively, if PyLibAPR is built with CUDA enabled and psf is of size (3, 3, 3) or (5, 5, 5)
+# pyapr.numerics.richardson_lucy_cuda(apr, fparts, output, psf, niter, use_stencil_downsample=True,
+#                                     normalize_stencil=True, resume=False)
 
-    # Alternatively, if PyLibAPR is built with CUDA enabled and psf is of size (3, 3, 3) or (5, 5, 5)
-    # pyapr.numerics.richardson_lucy_cuda(apr, fparts, output, psf, niter, use_stencil_downsample=True,
-    #                                     normalize_stencil=True, resume=False)
-
-    # Display the result
-    pyapr.viewer.parts_viewer(apr, output)
-
-
-if __name__ == '__main__':
-    main()
+# Display the result
+pyapr.viewer.parts_viewer(apr, output)

--- a/demo/richardson_lucy_demo.py
+++ b/demo/richardson_lucy_demo.py
@@ -41,14 +41,18 @@ print('RLTV took {} seconds'.format(time()-t0))
 
 
 # Alternatively, if PyLibAPR is built with CUDA enabled and psf is of size (3, 3, 3) or (5, 5, 5)
+cuda = False
 if pyapr.cuda_build() and psf.shape in [(3, 3, 3), (5, 5, 5)]:
     t0 = time()
-    output = pyapr.FloatParticles()
-    pyapr.numerics.richardson_lucy_cuda(apr, parts, output, psf, niter, use_stencil_downsample=False,
+    output_cuda = pyapr.FloatParticles()
+    pyapr.numerics.richardson_lucy_cuda(apr, parts, output_cuda, psf, niter, use_stencil_downsample=True,
                                         normalize_stencil=True, resume=False)
     print('RL cuda took {} seconds'.format(time()-t0))
+    cuda = True
 
 
 # Display the result
 pyapr.viewer.parts_viewer(apr, output)
 pyapr.viewer.parts_viewer(apr, output_tv)
+if cuda:
+    pyapr.viewer.parts_viewer(apr, output_cuda)

--- a/demo/viewer_demo.py
+++ b/demo/viewer_demo.py
@@ -1,26 +1,16 @@
 import pyapr
 
 
-def main():
-    """
-    Read a selected APR from file and display it in the z-slice viewer.
-    """
+"""
+Read a selected APR from file and display it in the z-slice viewer.
+"""
 
-    # Get APR file path from gui
-    io_int = pyapr.filegui.InteractiveIO()
-    fpath_apr = io_int.get_apr_file_name()
+# Get APR file path from gui
+io_int = pyapr.filegui.InteractiveIO()
+fpath_apr = io_int.get_apr_file_name()
 
-    # Instantiate APR and particles objects
-    apr = pyapr.APR()
-    parts = pyapr.ShortParticles()
-    # parts = pyapr.FloatParticles()
+# Read APR and particles from file
+apr, parts = pyapr.io.read(fpath_apr)
 
-    # Read APR and particles from file
-    pyapr.io.read(fpath_apr, apr, parts)
-
-    # Launch the by-slice viewer
-    pyapr.viewer.parts_viewer(apr, parts)
-
-
-if __name__ == '__main__':
-    main()
+# Launch the by-slice viewer
+pyapr.viewer.parts_viewer(apr, parts)

--- a/pyapr/__init__.py
+++ b/pyapr/__init__.py
@@ -30,7 +30,7 @@ from . import numerics
 from . import viewer
 
 
-def cuda_build():
+def cuda_enabled():
     return __cuda_build__
 
 

--- a/pyapr/__init__.py
+++ b/pyapr/__init__.py
@@ -1,26 +1,3 @@
-"""Python wrappers for LibAPR
-
-The main package of pyapr contains no features. These are instead available through the following subpackages:
-
-Subpackages
------------
-
-data_containers
-    fundamental data container classes
-
-converter
-    templated classes for creating APRs from images of different data types
-
-io
-    reading and writing APRs from/to file
-
-numerics
-    subpackage for processing using APRs
-
-viewer
-    a simple graphical user interface for visualizing results and exploring parameters
-"""
-__cuda_build__ = __import__('_pyaprwrapper').__cuda_build__
 from . import data_containers
 from .data_containers import *
 from .filegui import InteractiveIO
@@ -28,6 +5,11 @@ from . import converter
 from . import io
 from . import numerics
 from . import viewer
+
+try:
+    from _pyaprwrapper import __cuda_build__
+except ImportError:
+    __cuda_build__ = False
 
 
 def cuda_enabled():

--- a/pyapr/__init__.py
+++ b/pyapr/__init__.py
@@ -20,7 +20,7 @@ numerics
 viewer
     a simple graphical user interface for visualizing results and exploring parameters
 """
-
+__cuda_build__ = __import__('_pyaprwrapper').__cuda_build__
 from . import data_containers
 from .data_containers import *
 from .filegui import InteractiveIO
@@ -29,4 +29,9 @@ from . import io
 from . import numerics
 from . import viewer
 
-__all__ = ['data_containers', 'io', 'viewer', 'converter', 'numerics', 'tests']
+
+def cuda_build():
+    return __cuda_build__
+
+
+__all__ = ['data_containers', 'io', 'viewer', 'converter', 'numerics']

--- a/pyapr/converter/PyAPRConverter.hpp
+++ b/pyapr/converter/PyAPRConverter.hpp
@@ -31,18 +31,6 @@ public:
         return this->par;
     }
 
-    PixelData<T>& get_gradient() {
-        return this->grad_temp;
-    }
-
-    PixelData<float>& get_intensity_scale() {
-        return this->local_scale_temp;
-    }
-
-    PixelData<float>& get_smooth_image() {
-        return this->local_scale_temp2;
-    }
-
     /**
      * Compute an APR from a given image, given as a numpy array.
      * @param apr
@@ -197,12 +185,6 @@ void AddPyAPRConverter(pybind11::module &m, const std::string &aTypeString) {
                  py::arg("apr"), py::arg("img").noconvert())
             .def("set_parameters", &converter::set_parameters, "set parameters")
             .def("get_parameters", &converter::get_parameters, "get parameters")
-            .def("get_gradient", &converter::get_gradient, "return B-spline gradient",
-                 py::return_value_policy::reference)
-            .def("get_intensity_scale", &converter::get_intensity_scale, "return local intensity scale",
-                 py::return_value_policy::reference)
-            .def("get_smooth_image", &converter::get_smooth_image, "return B-spline smoothed image",
-                 py::return_value_policy::reference)
             .def("get_level_slice", &converter::get_level_slice,
                  "gets the current level slice for the applied parameters")
             .def("get_apr_step1", &converter::template get_apr_step1<float>, "Interactive APR generation",

--- a/pyapr/converter/converter_methods.py
+++ b/pyapr/converter/converter_methods.py
@@ -32,6 +32,10 @@ def get_apr(image: np.ndarray,
     A tuple (apr, parts) where apr is the APR object and parts is the sampled particle data object of type
     FloatParticles or ShortParticles (depending on the input image data type).
     """
+    if not image.flags['C_CONTIGUOUS']:
+        print('WARNING: \'image\' argument given to get_apr is not C-contiguous \n'
+              'input image has been replaced with a C-contiguous copy of itself')
+        image = np.ascontiguousarray(image)
 
     if image.dtype not in __allowed_image_types__:
         errstr = 'pyapr.converter.get_apr accepts images of type float32, uint16 and uint8, ' \
@@ -96,6 +100,10 @@ def get_apr_interactive(image: np.ndarray,
     A tuple (apr, parts) where apr is the APR object and parts is the sampled particle data object of type
     FloatParticles or ShortParticles (depending on the input image data type).
     """
+    if not image.flags['C_CONTIGUOUS']:
+        print('WARNING: \'image\' argument given to get_apr_interactive is not C-contiguous \n'
+              'input image has been replaced with a C-contiguous copy of itself')
+        image = np.ascontiguousarray(image)
 
     if image.dtype not in __allowed_image_types__:
         errstr = 'pyapr.converter.get_apr accepts images of type float32, uint16 and uint8, ' \
@@ -143,6 +151,10 @@ def find_parameters_interactive(image: np.ndarray,
                                 verbose: bool = False,
                                 slider_decimals: int = 1):
     """Same as `get_apr_interactive` but simply returns the selected parameters"""
+    if not image.flags['C_CONTIGUOUS']:
+        print('WARNING: \'image\' argument given to find_parameters_interactive is not C-contiguous \n'
+              'input image has been replaced with a C-contiguous copy of itself')
+        image = np.ascontiguousarray(image)
 
     if image.dtype not in __allowed_image_types__:
         errstr = 'pyapr.converter.find_parameters_interactive accepts input images of type float32, uint16 and uint8, ' \

--- a/pyapr/converter/converter_methods.py
+++ b/pyapr/converter/converter_methods.py
@@ -1,57 +1,106 @@
 import pyapr
+from pyapr.converter import FloatConverter, ShortConverter
 import numpy as np
+from typing import Union, Optional
 
 
-def get_apr(image, rel_error=0.1, gradient_smoothing=2, verbose=True, params=None):
+__allowed_image_types__ = [np.uint8, np.uint16, np.float32]
 
-    # check that the image array is c-contiguous
-    if not image.flags['C_CONTIGUOUS']:
-        print('WARNING: \'image\' argument given to get_apr is not C-contiguous \n'
-              'input image has been replaced with a C-contiguous copy of itself')
-        image = np.ascontiguousarray(image)
 
-    # Initialize objects
-    apr = pyapr.APR()
+def get_apr(image: np.ndarray,
+            converter: Optional[Union[FloatConverter, ShortConverter]] = None,
+            params: Optional[pyapr.APRParameters] = None,
+            verbose: bool = False):
+    """
+    Convert an image array to the APR.
 
-    if params is None:
-        par = pyapr.APRParameters()
-        par.auto_parameters = True
-        par.rel_error = rel_error
-        par.gradient_smoothing = gradient_smoothing
-    else:
-        par = params
+    Parameters
+    ----------
+    image: numpy.ndarray
+        Input (pixel) image as an array of 1-3 dimensions.
+    converter: FloatConverter or ShortConverter (optional)
+        Converter object used to compute the APR. By default, FloatConverter is used to avoid rounding errors in
+        internal steps.
+    params: pyapr.APRParameters (optional)
+        If provided, sets parameters of the converter. If not, the parameters of the converter object is used, with
+        'auto_parameters' set to True.
+    verbose: bool
+        Set the verbose mode of the converter (default: False).
 
-    if image.dtype == np.float32:
-        parts = pyapr.FloatParticles()
-        converter = pyapr.converter.FloatConverter()
-    elif image.dtype == np.uint16:
-        parts = pyapr.ShortParticles()
-        converter = pyapr.converter.ShortConverter()
-    # elif image.dtype in {'byte', 'uint8'}:  # currently not working
-    #     parts = pyapr.ByteParticles()
-    #     converter = pyapr.converter.ByteConverter()
-    else:
-        errstr = 'pyapr.converter.get_apr: input image dtype must be numpy.uint16 or numpy.float32, ' \
+    Returns
+    -------
+    A tuple (apr, parts) where apr is the APR object and parts is the sampled particle data object of type
+    FloatParticles or ShortParticles (depending on the input image data type).
+    """
+
+    if image.dtype not in __allowed_image_types__:
+        errstr = 'pyapr.converter.get_apr accepts images of type float32, uint16 and uint8, ' \
                  'but {} was given'.format(image.dtype)
         raise TypeError(errstr)
+
+    # initialize objects
+    apr = pyapr.APR()
+    converter = converter or pyapr.converter.FloatConverter()
+
+    # set parameters
+    if params is None:
+        par = converter.get_parameters()
+        par.auto_parameters = True
+    else:
+        par = params
 
     converter.set_parameters(par)
     converter.verbose = verbose
 
-    # Compute the APR and sample particles
+    if image.dtype == np.float32:
+        parts = pyapr.FloatParticles()
+    else:
+        parts = pyapr.ShortParticles()
+
+    # compute the APR and sample particles
     converter.get_apr(apr, image)
     parts.sample_image(apr, image)
+
+    if verbose:
+        print('Total number of particles: {}'.format(apr.total_number_particles()))
+        print('Compuatational Ratio: {}'.format(apr.computational_ratio()))
 
     return apr, parts
 
 
-def get_apr_interactive(image, rel_error=0.1, gradient_smoothing=2, verbose=True, params=None, slider_decimals=1):
+def get_apr_interactive(image: np.ndarray,
+                        converter: Optional[Union[FloatConverter, ShortConverter]] = None,
+                        params: Optional[pyapr.APRParameters] = None,
+                        verbose: bool = False,
+                        slider_decimals: int = 1):
+    """
+    Interactively convert an image array to the APR. The parameters `Ip_th`, `sigma_th` and `grad_th` are set
+    with visual feedback.
 
-    # check that the image array is c-contiguous
-    if not image.flags['C_CONTIGUOUS']:
-        print('WARNING: \'image\' argument given to get_apr_interactive is not C-contiguous \n'
-              'input image has been replaced with a C-contiguous copy of itself')
-        image = np.ascontiguousarray(image)
+    Parameters
+    ----------
+    image: numpy.ndarray
+        Input (pixel) image as an array of 1-3 dimensions.
+    converter: FloatConverter or ShortConverter (optional)
+        Converter object used to compute the APR. By default, FloatConverter is used to avoid rounding errors in
+        internal steps.
+    params: pyapr.APRParameters (optional)
+        If provided, sets parameters of the converter. Otherwise default parameters are used.
+    verbose: bool
+        Set the verbose mode of the converter (default: False).
+    slider_decimals: int
+        Number of decimals to use in the parameter sliders.
+
+    Returns
+    -------
+    A tuple (apr, parts) where apr is the APR object and parts is the sampled particle data object of type
+    FloatParticles or ShortParticles (depending on the input image data type).
+    """
+
+    if image.dtype not in __allowed_image_types__:
+        errstr = 'pyapr.converter.get_apr accepts images of type float32, uint16 and uint8, ' \
+                 'but {} was given'.format(image.dtype)
+        raise TypeError(errstr)
 
     while image.ndim < 3:
         image = np.expand_dims(image, axis=0)
@@ -59,40 +108,28 @@ def get_apr_interactive(image, rel_error=0.1, gradient_smoothing=2, verbose=True
     # Initialize objects
     io_int = pyapr.InteractiveIO()
     apr = pyapr.APR()
+    converter = converter or pyapr.converter.FloatConverter()
 
     if params is None:
-        par = pyapr.APRParameters()
+        par = converter.get_parameters()
         par.auto_parameters = False
-        par.rel_error = rel_error
-        par.gradient_smoothing = gradient_smoothing
     else:
         par = params
 
-    if image.dtype == np.float32:
-        parts = pyapr.FloatParticles()
-        converter = pyapr.converter.FloatConverter()
-    elif image.dtype == np.uint16:
-        parts = pyapr.ShortParticles()
-        converter = pyapr.converter.ShortConverter()
-    # elif image.dtype in {'byte', 'uint8'}:  # currently not working
-    #     parts = pyapr.ByteParticles()
-    #     converter = pyapr.converter.ByteConverter()
-    else:
-        errstr = 'pyapr.converter.get_apr_interactive: input image dtype must be numpy.uint16 or numpy.float32, ' \
-                 'but {} was given'.format(image.dtype)
-        raise TypeError(errstr)
-
     converter.set_parameters(par)
     converter.verbose = verbose
+
+    if image.dtype == np.float32:
+        parts = pyapr.FloatParticles()
+    else:
+        parts = pyapr.ShortParticles()
 
     # launch interactive APR converter
     io_int.interactive_apr(converter, apr, image, slider_decimals=slider_decimals)
 
     if verbose:
-        print("Total number of particles: {}".format(apr.total_number_particles()))
-        print("Number of pixels in original image: {}".format(image.size))
-        cr = image.size/apr.total_number_particles()
-        print("Compuational Ratio: {:7.2f}".format(cr))
+        print('Total number of particles: {}'.format(apr.total_number_particles()))
+        print('Compuatational Ratio: {}'.format(apr.computational_ratio()))
 
     # sample particles
     parts.sample_image(apr, image)
@@ -100,13 +137,17 @@ def get_apr_interactive(image, rel_error=0.1, gradient_smoothing=2, verbose=True
     return apr, parts
 
 
-def find_parameters_interactive(image, rel_error=0.1, gradient_smoothing=0, verbose=True, params=None, slider_decimals=1):
+def find_parameters_interactive(image: np.ndarray,
+                                converter: Optional[Union[FloatConverter, ShortConverter]] = None,
+                                params: Optional[pyapr.APRParameters] = None,
+                                verbose: bool = False,
+                                slider_decimals: int = 1):
+    """Same as `get_apr_interactive` but simply returns the selected parameters"""
 
-    # check that the image array is c-contiguous
-    if not image.flags['C_CONTIGUOUS']:
-        print('WARNING: \'image\' argument given to find_parameters_interactive is not C-contiguous \n'
-              'input image has been replaced with a C-contiguous copy of itself')
-        image = np.ascontiguousarray(image)
+    if image.dtype not in __allowed_image_types__:
+        errstr = 'pyapr.converter.find_parameters_interactive accepts input images of type float32, uint16 and uint8, ' \
+                 'but {} was given'.format(image.dtype)
+        raise TypeError(errstr)
 
     while image.ndim < 3:
         image = np.expand_dims(image, axis=0)
@@ -114,24 +155,13 @@ def find_parameters_interactive(image, rel_error=0.1, gradient_smoothing=0, verb
     # Initialize objects
     io_int = pyapr.filegui.InteractiveIO()
     apr = pyapr.APR()
+    converter = converter or pyapr.converter.FloatConverter()
+
     if params is None:
-        par = pyapr.APRParameters()
+        par = converter.get_parameters()
         par.auto_parameters = False
-        par.rel_error = rel_error
-        par.gradient_smoothing = gradient_smoothing
     else:
         par = params
-
-    if image.dtype == np.float32:
-        converter = pyapr.converter.FloatConverter()
-    elif image.dtype == np.uint16:
-        converter = pyapr.converter.ShortConverter()
-    # elif image.dtype in {'byte', 'uint8'}:  # currently not working
-    #     converter = pyapr.converter.ByteConverter()
-    else:
-        errstr = 'pyapr.converter.find_parameters_interactive: input image dtype must be numpy.uint16 or numpy.float32, ' \
-                 'but {} was given'.format(image.dtype)
-        raise TypeError(errstr)
 
     converter.set_parameters(par)
     converter.verbose = verbose

--- a/pyapr/data_containers/PyParticleData.hpp
+++ b/pyapr/data_containers/PyParticleData.hpp
@@ -43,6 +43,11 @@ public:
         std::copy(ptr, ptr+buf.size, this->begin());
     }
 
+    template<typename S>
+    PyParticleData(PyParticleData<S>& other) {
+        this->copy(other);
+    }
+
     bool contains(T val) const {
         for(size_t i = 0; i < this->size(); ++i) {
             if(this->data[i] == val) {
@@ -493,9 +498,13 @@ void AddPyParticleData(pybind11::module &m, const std::string &aTypeString) {
     std::string typeStr = aTypeString + "Particles";
     py::class_<TypeParticles, BaseParticles>(m, typeStr.c_str(), py::buffer_protocol())
             .def(py::init())
-            .def(py::init([](uint64_t num_particles) { return new TypeParticles(num_particles); }))
-            .def(py::init([](APR& apr) { return new TypeParticles(apr); }))
-            .def(py::init([](py::array_t<DataType, py::array::c_style | py::array::forcecast>& arr){ return new TypeParticles(arr); }))
+            .def(py::init([](uint64_t num_particles) { return TypeParticles(num_particles); }))
+            .def(py::init([](APR& apr) { return TypeParticles(apr); }))
+            .def(py::init([](py::array_t<DataType, py::array::c_style | py::array::forcecast>& arr){ return TypeParticles(arr); }))
+            .def(py::init([](PyParticleData<float>& other){ return TypeParticles(other); }))
+            .def(py::init([](PyParticleData<uint8_t>& other){ return TypeParticles(other); }))
+            .def(py::init([](PyParticleData<uint16_t>& other){ return TypeParticles(other); }))
+            .def(py::init([](PyParticleData<uint64_t>& other){ return TypeParticles(other); }))
             .def("__len__", [](const TypeParticles &p){ return p.size(); })
             .def("__contains__", [](const TypeParticles &p, DataType v) { return p.contains(v); })
             .def("resize", &TypeParticles::resize, "resize the data array to a specified number of elements")

--- a/pyapr/tests/testAPR.py
+++ b/pyapr/tests/testAPR.py
@@ -78,9 +78,6 @@ class BasicTests(unittest.TestCase):
             self.__convert_image(self.impath_1D, np.float64)
 
         with self.assertRaises(TypeError):
-            self.__convert_image(self.impath_1D, np.uint8)
-
-        with self.assertRaises(TypeError):
             self.__convert_image(self.impath_1D, int)
 
     def test_io(self):

--- a/wrappers/pythonBind.cpp
+++ b/wrappers/pythonBind.cpp
@@ -3,12 +3,8 @@
 // Modified by Joel Jonsson on 2/5/19.
 //
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/numpy.h>
-
 #include <ConfigAPR.h>
-
+#include <pybind11/pybind11.h>
 #include "data_containers/PyPixelData.hpp"
 #include "data_containers/PyAPR.hpp"
 #include "data_containers/PyAPRParameters.hpp"
@@ -27,6 +23,12 @@
 #include "viewer/ViewerHelpers.hpp"
 #include "viewer/PyAPRRaycaster.hpp"
 
+#ifdef PYAPR_USE_CUDA
+#define BUILT_WITH_CUDA true
+#else
+#define BUILT_WITH_CUDA false
+#endif
+
 namespace py = pybind11;
 
 // -------- Check if properly configured in CMAKE -----------------------------
@@ -38,6 +40,7 @@ namespace py = pybind11;
 PYBIND11_MODULE(APR_PYTHON_MODULE_NAME, m) {
     m.doc() = "python binding for LibAPR library";
     m.attr("__version__") = py::str(ConfigAPR::APR_VERSION);
+    m.attr("__cuda_build__") = BUILT_WITH_CUDA;
 
     py::module data_containers = m.def_submodule("data_containers");
 


### PR DESCRIPTION
- add templates for `get_apr*` methods and `sample_image` based on input array data type
- disable conversion of input arrays for these methods (previously the array would be cast to the type of the converter/particledata object, which may lead to unwanted effects that can be difficult to track down)
- update get_apr* python functions for increased flexibility
- add copy constructors for python particledata classes, allowing one-line conversion between types
- update demos to improve readability 